### PR TITLE
fix: support modern esm and types resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,13 @@
   "name": "@stream-io/node-sdk",
   "version": "0.3.0",
   "description": "",
+  "exports": {
+    ".": {
+      "import": "./dist/index.es.js",
+      "require": "./dist/index.cjs.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Currently, the package won't run with vite/rollup which is arguably one of the most (if not the most) popular bundler setup.

First, it would use a CJS build instead of ESM build even in pure ESM (`"type": "module"`) projects. This is because the ESM build is not published in a [standard-compliant way](https://nodejs.org/api/packages.html#approach-2-isolate-state).

Then, with CJS build, it will not import sub-deps properly:

```js
function JWTServerToken(apiSecret, jwtOptions = {}) {
    const payload = {
        server: true,
    };
    const opts = Object.assign({ algorithm: 'HS256', noTimestamp: true }, jwtOptions);
    return jwt.sign(payload, apiSecret, opts); // <------- here it will crash
    // because jwt is { default: { sign: ... } }
}
```

Then, under some circumstances the types won't load with modern Typescript setup ("moduleResolution" set to "Node16" or "Bundler") with this error: _...There are types at '/......./types/index.d.ts', but this result could not be resolved when respecting package.json "exports".ts(7016)_

All and all, the project's `package.json` is missing the `exports` section which modern packages should have. The PR adds one.

Also, the top-level `module` property should be removed from `package.json` as there is no such field officially. It could have been supported privately by some bundlers but now everything supports `exports`. I kept `module` in this PR as you may have been relying on it somehow—but please consider removing it.