### PR TITLE
chore: typo in `engines` declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,5 +74,7 @@
     "jsonwebtoken": "^9.0.2",
     "uuid": "^9.0.1"
   },
-  "enginges": ">=18.0.0"
+  "engines": {
+    "node": ">=18.0.0"
+  }
 }


### PR DESCRIPTION
### Overview

Fixes a typo in the `engines` declaration and switches to standardized spec:
- https://docs.npmjs.com/cli/v10/configuring-npm/package-json#engines