### PR TITLE
feat: add method and request/response for new endpoint

### DIFF
--- a/src/gen/common/CommonApi.ts
+++ b/src/gen/common/CommonApi.ts
@@ -132,6 +132,7 @@ export class CommonApi {
       sqs_key: request?.sqs_key,
       sqs_secret: request?.sqs_secret,
       sqs_url: request?.sqs_url,
+      user_response_time_enabled: request?.user_response_time_enabled,
       webhook_url: request?.webhook_url,
       allowed_flag_reasons: request?.allowed_flag_reasons,
       event_hooks: request?.event_hooks,
@@ -1379,7 +1380,6 @@ export class CommonApi {
       user_id: request?.user_id,
     };
     const body = {
-      created_by_device_id: request?.created_by_device_id,
       message_id: request?.message_id,
       end_at: request?.end_at,
       latitude: request?.latitude,

--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -47,6 +47,8 @@ import {
   GetFollowSuggestionsResponse,
   GetOrCreateFeedRequest,
   GetOrCreateFeedResponse,
+  GetOrCreateFeedViewRequest,
+  GetOrCreateFeedViewResponse,
   ListFeedGroupsResponse,
   ListFeedViewsResponse,
   MarkActivityRequest,
@@ -1183,6 +1185,7 @@ export class FeedsApi {
       mark_all_seen: request?.mark_all_seen,
       user_id: request?.user_id,
       mark_read: request?.mark_read,
+      mark_seen: request?.mark_seen,
       mark_watched: request?.mark_watched,
       user: request?.user,
     };
@@ -1451,6 +1454,33 @@ export class FeedsApi {
     );
 
     decoders.CreateFeedViewResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getOrCreateFeedView(
+    request: GetOrCreateFeedViewRequest,
+  ): Promise<StreamResponse<GetOrCreateFeedViewResponse>> {
+    const body = {
+      view_id: request?.view_id,
+      activity_processors: request?.activity_processors,
+      activity_selectors: request?.activity_selectors,
+      aggregation: request?.aggregation,
+      ranking: request?.ranking,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetOrCreateFeedViewResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/feed_views/get_or_create',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.GetOrCreateFeedViewResponse?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }

--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -1458,33 +1458,6 @@ export class FeedsApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async getOrCreateFeedView(
-    request: GetOrCreateFeedViewRequest,
-  ): Promise<StreamResponse<GetOrCreateFeedViewResponse>> {
-    const body = {
-      view_id: request?.view_id,
-      activity_processors: request?.activity_processors,
-      activity_selectors: request?.activity_selectors,
-      aggregation: request?.aggregation,
-      ranking: request?.ranking,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<GetOrCreateFeedViewResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/feed_views/get_or_create',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.GetOrCreateFeedViewResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
   async deleteFeedView(request: {
     view_id: string;
   }): Promise<StreamResponse<DeleteFeedViewResponse>> {
@@ -1513,6 +1486,35 @@ export class FeedsApi {
     >('GET', '/api/v2/feeds/feed_views/{view_id}', pathParams, undefined);
 
     decoders.GetFeedViewResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getOrCreateFeedView(
+    request: GetOrCreateFeedViewRequest & { view_id: string },
+  ): Promise<StreamResponse<GetOrCreateFeedViewResponse>> {
+    const pathParams = {
+      view_id: request?.view_id,
+    };
+    const body = {
+      activity_processors: request?.activity_processors,
+      activity_selectors: request?.activity_selectors,
+      aggregation: request?.aggregation,
+      ranking: request?.ranking,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetOrCreateFeedViewResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/feed_views/{view_id}',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.GetOrCreateFeedViewResponse?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }

--- a/src/gen/model-decoders/decoders.ts
+++ b/src/gen/model-decoders/decoders.ts
@@ -917,6 +917,15 @@ decoders.CallSessionEndedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
+decoders.CallSessionParticipantCountsUpdatedEvent = (
+  input?: Record<string, any>,
+) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
 decoders.CallSessionParticipantJoinedEvent = (input?: Record<string, any>) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
@@ -1944,6 +1953,8 @@ decoders.FeedResponse = (input?: Record<string, any>) => {
     created_by: { type: 'UserResponse', isSingle: true },
 
     deleted_at: { type: 'DatetimeType', isSingle: true },
+
+    own_follows: { type: 'FollowResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
@@ -2286,6 +2297,13 @@ decoders.GetOrCreateFeedResponse = (input?: Record<string, any>) => {
     notification_status: { type: 'NotificationStatusResponse', isSingle: true },
 
     own_membership: { type: 'FeedMemberResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.GetOrCreateFeedViewResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    feed_view: { type: 'FeedViewResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
@@ -2860,6 +2878,24 @@ decoders.MuteResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
+decoders.NotificationFeedUpdatedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+
+    aggregated_activities: {
+      type: 'AggregatedActivityResponse',
+      isSingle: false,
+    },
+
+    notification_status: { type: 'NotificationStatusResponse', isSingle: true },
+
+    user: { type: 'UserResponseCommonFields', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
 decoders.NotificationMarkUnreadEvent = (input?: Record<string, any>) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
@@ -2875,6 +2911,8 @@ decoders.NotificationMarkUnreadEvent = (input?: Record<string, any>) => {
 
 decoders.NotificationStatusResponse = (input?: Record<string, any>) => {
   const typeMappings: TypeMapping = {
+    last_read_at: { type: 'DatetimeType', isSingle: true },
+
     last_seen_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
@@ -3451,6 +3489,39 @@ decoders.RejectFollowResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
+decoders.ReminderCreatedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+
+    reminder: { type: 'ReminderResponseData', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ReminderDeletedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+
+    reminder: { type: 'ReminderResponseData', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ReminderNotificationEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+
+    reminder: { type: 'ReminderResponseData', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
 decoders.ReminderResponseData = (input?: Record<string, any>) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
@@ -3464,6 +3535,17 @@ decoders.ReminderResponseData = (input?: Record<string, any>) => {
     message: { type: 'Message', isSingle: true },
 
     user: { type: 'User', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ReminderUpdatedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+
+    reminder: { type: 'ReminderResponseData', isSingle: true },
   };
   return decode(typeMappings, input);
 };
@@ -3814,6 +3896,20 @@ decoders.UnblockedUserEvent = (input?: Record<string, any>) => {
     created_at: { type: 'DatetimeType', isSingle: true },
 
     user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UnfollowBatchResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    follows: { type: 'FollowResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UnfollowResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    follow: { type: 'FollowResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -6106,8 +6106,6 @@ export interface GetOrCreateFeedResponse {
 }
 
 export interface GetOrCreateFeedViewRequest {
-  view_id: string;
-
   activity_processors?: ActivityProcessorConfig[];
 
   activity_selectors?: ActivitySelectorConfig[];

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -307,6 +307,8 @@ export interface ActivityMarkEvent {
 
   mark_read?: string[];
 
+  mark_seen?: string[];
+
   mark_watched?: string[];
 
   user?: UserResponseCommonFields;
@@ -531,7 +533,7 @@ export interface ActivityResponse {
 
   moderation?: ModerationV2Response;
 
-  object?: Record<string, any>;
+  notification_context?: Record<string, any>;
 
   parent?: ActivityResponse;
 
@@ -773,6 +775,8 @@ export interface AppResponseFields {
 
   image_moderation_enabled: boolean;
 
+  moderation_bulk_submit_action_enabled: boolean;
+
   moderation_enabled: boolean;
 
   moderation_multitenant_blocklist_enabled: boolean;
@@ -806,6 +810,8 @@ export interface AppResponseFields {
   suspended_explanation: string;
 
   use_hook_v2: boolean;
+
+  user_response_time_enabled: boolean;
 
   webhook_url: string;
 
@@ -1890,6 +1896,8 @@ export interface CallParticipant {
 
   teams_role: Record<string, string>;
 
+  avg_response_time?: number;
+
   ban_expires?: Date;
 
   created_at?: Date;
@@ -2191,6 +2199,20 @@ export interface CallSessionEndedEvent {
   type: string;
 }
 
+export interface CallSessionParticipantCountsUpdatedEvent {
+  anonymous_participant_count: number;
+
+  call_cid: string;
+
+  created_at: Date;
+
+  session_id: string;
+
+  participants_count_by_role: Record<string, number>;
+
+  type: string;
+}
+
 export interface CallSessionParticipantJoinedEvent {
   call_cid: string;
 
@@ -2266,6 +2288,8 @@ export interface CallSettings {
 
   geofencing?: GeofenceSettings;
 
+  ingress?: IngressSettings;
+
   limits?: LimitsSettings;
 
   recording?: RecordSettings;
@@ -2293,6 +2317,8 @@ export interface CallSettingsRequest {
   frame_recording?: FrameRecordingSettingsRequest;
 
   geofencing?: GeofenceSettingsRequest;
+
+  ingress?: IngressSettingsRequest;
 
   limits?: LimitsSettingsRequest;
 
@@ -2337,6 +2363,8 @@ export interface CallSettingsResponse {
   transcription: TranscriptionSettingsResponse;
 
   video: VideoSettingsResponse;
+
+  ingress?: IngressSettingsResponse;
 }
 
 export interface CallStateResponseFields {
@@ -4701,6 +4729,8 @@ export interface EntityCreator {
 
   teams_role: Record<string, string>;
 
+  avg_response_time?: number;
+
   ban_expires?: Date;
 
   created_at?: Date;
@@ -4756,6 +4786,8 @@ export interface EntityCreatorResponse {
   teams: string[];
 
   custom: Record<string, any>;
+
+  avg_response_time?: number;
 
   ban_expires?: Date;
 
@@ -5230,6 +5262,8 @@ export interface FeedResponse {
 
   filter_tags?: string[];
 
+  own_follows?: FollowResponse[];
+
   custom?: Record<string, any>;
 }
 
@@ -5350,29 +5384,33 @@ export interface FirebaseConfigFields {
 export interface Flag {
   created_at: Date;
 
-  created_by_automod: boolean;
+  entity_id: string;
+
+  entity_type: string;
 
   updated_at: Date;
 
-  approved_at?: Date;
+  result: Array<Record<string, any>>;
+
+  entity_creator_id?: string;
+
+  is_streamed_content?: boolean;
+
+  moderation_payload_hash?: string;
 
   reason?: string;
 
-  rejected_at?: Date;
+  review_queue_item_id?: string;
 
-  reviewed_at?: Date;
+  type?: string;
 
-  reviewed_by?: string;
-
-  target_message_id?: string;
+  labels?: string[];
 
   custom?: Record<string, any>;
 
-  details?: FlagDetails;
+  moderation_payload?: ModerationPayload;
 
-  target_message?: Message;
-
-  target_user?: User;
+  review_queue_item?: ReviewQueueItem;
 
   user?: User;
 }
@@ -5619,6 +5657,8 @@ export interface FullUserResponse {
   teams: string[];
 
   custom: Record<string, any>;
+
+  avg_response_time?: number;
 
   ban_expires?: Date;
 
@@ -6065,6 +6105,26 @@ export interface GetOrCreateFeedResponse {
   own_membership?: FeedMemberResponse;
 }
 
+export interface GetOrCreateFeedViewRequest {
+  view_id: string;
+
+  activity_processors?: ActivityProcessorConfig[];
+
+  activity_selectors?: ActivitySelectorConfig[];
+
+  aggregation?: AggregationConfig;
+
+  ranking?: RankingConfig;
+}
+
+export interface GetOrCreateFeedViewResponse {
+  duration: string;
+
+  was_created: boolean;
+
+  feed_view: FeedViewResponse;
+}
+
 export interface GetPushTemplatesResponse {
   duration: string;
 
@@ -6327,6 +6387,102 @@ export interface ImportTaskHistory {
   prev_state: string;
 }
 
+export interface IngressAudioEncodingOptions {
+  bitrate: number;
+
+  channels: '1' | '2';
+
+  enable_dtx: boolean;
+}
+
+export interface IngressAudioEncodingOptionsRequest {
+  bitrate: number;
+
+  channels: '1' | '2';
+
+  enable_dtx?: boolean;
+}
+
+export interface IngressAudioEncodingResponse {
+  bitrate: number;
+
+  channels: number;
+
+  enable_dtx: boolean;
+}
+
+export interface IngressSettings {
+  enabled: boolean;
+
+  audio_encoding_options?: IngressAudioEncodingOptions;
+
+  video_encoding_options?: Record<string, IngressVideoEncodingOptions>;
+}
+
+export interface IngressSettingsRequest {
+  enabled?: boolean;
+
+  audio_encoding_options?: IngressAudioEncodingOptionsRequest;
+
+  video_encoding_options?: Record<string, IngressVideoEncodingOptionsRequest>;
+}
+
+export interface IngressSettingsResponse {
+  enabled: boolean;
+
+  audio_encoding_options?: IngressAudioEncodingResponse;
+
+  video_encoding_options?: Record<string, IngressVideoEncodingResponse>;
+}
+
+export interface IngressVideoEncodingOptions {
+  layers: IngressVideoLayer[];
+}
+
+export interface IngressVideoEncodingOptionsRequest {
+  layers: IngressVideoLayerRequest[];
+}
+
+export interface IngressVideoEncodingResponse {
+  layers: IngressVideoLayerResponse[];
+}
+
+export interface IngressVideoLayer {
+  bitrate: number;
+
+  codec: 'h264' | 'vp8';
+
+  frame_rate: number;
+
+  max_dimension: number;
+
+  min_dimension: number;
+}
+
+export interface IngressVideoLayerRequest {
+  bitrate: number;
+
+  codec: 'h264' | 'vp8';
+
+  frame_rate_limit: number;
+
+  max_dimension: number;
+
+  min_dimension: number;
+}
+
+export interface IngressVideoLayerResponse {
+  bitrate: number;
+
+  codec: string;
+
+  frame_rate_limit: number;
+
+  max_dimension: number;
+
+  min_dimension: number;
+}
+
 export interface JoinCallAPIMetrics {
   failures: number;
 
@@ -6515,6 +6671,8 @@ export interface MarkActivityRequest {
   user_id?: string;
 
   mark_read?: string[];
+
+  mark_seen?: string[];
 
   mark_watched?: string[];
 
@@ -7445,6 +7603,24 @@ export interface NotificationConfig {
   track_seen?: boolean;
 }
 
+export interface NotificationFeedUpdatedEvent {
+  created_at: Date;
+
+  fid: string;
+
+  custom: Record<string, any>;
+
+  type: string;
+
+  received_at?: Date;
+
+  aggregated_activities?: AggregatedActivityResponse[];
+
+  notification_status?: NotificationStatusResponse;
+
+  user?: UserResponseCommonFields;
+}
+
 export interface NotificationMarkUnreadEvent {
   channel_id: string;
 
@@ -7502,9 +7678,13 @@ export interface NotificationStatusResponse {
 
   unseen: number;
 
+  last_read_at?: Date;
+
   last_seen_at?: Date;
 
   read_activities?: string[];
+
+  seen_activities?: string[];
 }
 
 export interface NullTime {}
@@ -7594,6 +7774,8 @@ export interface OwnUser {
 
   total_unread_count_by_team: Record<string, number>;
 
+  avg_response_time?: number;
+
   deactivated_at?: Date;
 
   deleted_at?: Date;
@@ -7651,6 +7833,8 @@ export interface OwnUserResponse {
   teams: string[];
 
   custom: Record<string, any>;
+
+  avg_response_time?: number;
 
   deactivated_at?: Date;
 
@@ -9457,6 +9641,66 @@ export interface RejectFollowResponse {
   follow: FollowResponse;
 }
 
+export interface ReminderCreatedEvent {
+  cid: string;
+
+  created_at: Date;
+
+  message_id: string;
+
+  user_id: string;
+
+  custom: Record<string, any>;
+
+  type: string;
+
+  parent_id?: string;
+
+  received_at?: Date;
+
+  reminder?: ReminderResponseData;
+}
+
+export interface ReminderDeletedEvent {
+  cid: string;
+
+  created_at: Date;
+
+  message_id: string;
+
+  user_id: string;
+
+  custom: Record<string, any>;
+
+  type: string;
+
+  parent_id?: string;
+
+  received_at?: Date;
+
+  reminder?: ReminderResponseData;
+}
+
+export interface ReminderNotificationEvent {
+  cid: string;
+
+  created_at: Date;
+
+  message_id: string;
+
+  user_id: string;
+
+  custom: Record<string, any>;
+
+  type: string;
+
+  parent_id?: string;
+
+  received_at?: Date;
+
+  reminder?: ReminderResponseData;
+}
+
 export interface ReminderResponseData {
   channel_cid: string;
 
@@ -9475,6 +9719,26 @@ export interface ReminderResponseData {
   message?: Message;
 
   user?: User;
+}
+
+export interface ReminderUpdatedEvent {
+  cid: string;
+
+  created_at: Date;
+
+  message_id: string;
+
+  user_id: string;
+
+  custom: Record<string, any>;
+
+  type: string;
+
+  parent_id?: string;
+
+  received_at?: Date;
+
+  reminder?: ReminderResponseData;
 }
 
 export interface RepliesMeta {
@@ -9558,11 +9822,19 @@ export interface ReviewQueueItem {
 
   bans: Ban[];
 
+  flag_labels: string[];
+
+  flag_types: string[];
+
   flags: Flag[];
 
   languages: string[];
 
+  reporter_ids: string[];
+
   teams: string[];
+
+  archived_at: NullTime;
 
   completed_at: NullTime;
 
@@ -10466,6 +10738,7 @@ export interface SubmitActionRequest {
     | 'delete_user'
     | 'unblock'
     | 'shadow_block'
+    | 'unmask'
     | 'kick_user'
     | 'end_call';
 
@@ -11042,10 +11315,14 @@ export interface UnfollowBatchRequest {
 
 export interface UnfollowBatchResponse {
   duration: string;
+
+  follows: FollowResponse[];
 }
 
 export interface UnfollowResponse {
   duration: string;
+
+  follow: FollowResponse;
 }
 
 export interface UnmuteChannelRequest {
@@ -11129,7 +11406,7 @@ export interface UnreadCountsResponse {
 
   threads: UnreadCountsThread[];
 
-  total_unread_count_by_team: Record<string, number>;
+  total_unread_count_by_team?: Record<string, number>;
 }
 
 export interface UnreadCountsThread {
@@ -11242,6 +11519,8 @@ export interface UpdateAppRequest {
   sqs_secret?: string;
 
   sqs_url?: string;
+
+  user_response_time_enabled?: boolean;
 
   webhook_url?: string;
 
@@ -11719,8 +11998,6 @@ export interface UpdateFollowResponse {
 }
 
 export interface UpdateLiveLocationRequest {
-  created_by_device_id: string;
-
   message_id: string;
 
   end_at?: Date;
@@ -12038,6 +12315,8 @@ export interface User {
 
   teams_role: Record<string, string>;
 
+  avg_response_time?: number;
+
   ban_expires?: Date;
 
   created_at?: Date;
@@ -12260,6 +12539,8 @@ export interface UserResponse {
 
   custom: Record<string, any>;
 
+  avg_response_time?: number;
+
   ban_expires?: Date;
 
   deactivated_at?: Date;
@@ -12304,6 +12585,8 @@ export interface UserResponseCommonFields {
 
   custom: Record<string, any>;
 
+  avg_response_time?: number;
+
   deactivated_at?: Date;
 
   deleted_at?: Date;
@@ -12339,6 +12622,8 @@ export interface UserResponsePrivacyFields {
   teams: string[];
 
   custom: Record<string, any>;
+
+  avg_response_time?: number;
 
   deactivated_at?: Date;
 
@@ -12641,6 +12926,9 @@ export type WebhookEvent =
   | ({ type: 'call.rtmp_broadcast_stopped' } & CallRtmpBroadcastStoppedEvent)
   | ({ type: 'call.session_ended' } & CallSessionEndedEvent)
   | ({
+      type: 'call.session_participant_count_updated';
+    } & CallSessionParticipantCountsUpdatedEvent)
+  | ({
       type: 'call.session_participant_joined';
     } & CallSessionParticipantJoinedEvent)
   | ({
@@ -12715,6 +13003,7 @@ export type WebhookEvent =
   | ({ type: 'feeds.follow.created' } & FollowCreatedEvent)
   | ({ type: 'feeds.follow.deleted' } & FollowDeletedEvent)
   | ({ type: 'feeds.follow.updated' } & FollowUpdatedEvent)
+  | ({ type: 'feeds.notification_feed.updated' } & NotificationFeedUpdatedEvent)
   | ({ type: 'flag.updated' } & FlagUpdatedEvent)
   | ({ type: 'member.added' } & MemberAddedEvent)
   | ({ type: 'member.removed' } & MemberRemovedEvent)
@@ -12732,10 +13021,14 @@ export type WebhookEvent =
   | ({ type: 'moderation.mark_reviewed' } & ModerationMarkReviewedEvent)
   | ({ type: 'moderation_check.completed' } & ModerationCheckCompletedEvent)
   | ({ type: 'notification.mark_unread' } & NotificationMarkUnreadEvent)
+  | ({ type: 'notification.reminder_due' } & ReminderNotificationEvent)
   | ({ type: 'notification.thread_message_new' } & MessageNewEvent)
   | ({ type: 'reaction.deleted' } & ReactionDeletedEvent)
   | ({ type: 'reaction.new' } & ReactionNewEvent)
   | ({ type: 'reaction.updated' } & ReactionUpdatedEvent)
+  | ({ type: 'reminder.created' } & ReminderCreatedEvent)
+  | ({ type: 'reminder.deleted' } & ReminderDeletedEvent)
+  | ({ type: 'reminder.updated' } & ReminderUpdatedEvent)
   | ({ type: 'review_queue_item.new' } & ReviewQueueItemNewEvent)
   | ({ type: 'review_queue_item.updated' } & ReviewQueueItemUpdatedEvent)
   | ({ type: 'thread.updated' } & ThreadUpdatedEvent)
@@ -12763,7 +13056,7 @@ export interface WrappedUnreadCountsResponse {
 
   threads: UnreadCountsThread[];
 
-  total_unread_count_by_team: Record<string, number>;
+  total_unread_count_by_team?: Record<string, number>;
 }
 
 export interface XiaomiConfig {


### PR DESCRIPTION
This PR adds a new method and corresponding request/response types to support QA testing for the new endpoint. Code generated with `yarn generate:open-api`. 
Link to task: https://linear.app/stream/issue/FEEDS-639/implement-getorcreatefeedview-endpoint