### PR TITLE
feat: Added create membership level method, request and response

### DIFF
--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -25,6 +25,8 @@ import {
   CreateFeedViewResponse,
   CreateFeedsBatchRequest,
   CreateFeedsBatchResponse,
+  CreateMembershipLevelRequest,
+  CreateMembershipLevelResponse,
   DeleteActivitiesRequest,
   DeleteActivitiesResponse,
   DeleteActivityReactionResponse,
@@ -1826,6 +1828,34 @@ export class FeedsApi {
     );
 
     decoders.UnfollowResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async createMembershipLevel(
+    request: CreateMembershipLevelRequest,
+  ): Promise<StreamResponse<CreateMembershipLevelResponse>> {
+    const body = {
+      id: request?.id,
+      name: request?.name,
+      description: request?.description,
+      priority: request?.priority,
+      tags: request?.tags,
+      custom: request?.custom,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<CreateMembershipLevelResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/membership_levels',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.CreateMembershipLevelResponse?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }

--- a/src/gen/model-decoders/decoders.ts
+++ b/src/gen/model-decoders/decoders.ts
@@ -1656,6 +1656,13 @@ decoders.CreateImportResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
+decoders.CreateMembershipLevelResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    membership_level: { type: 'MembershipLevelResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
 decoders.CreateRoleResponse = (input?: Record<string, any>) => {
   const typeMappings: TypeMapping = {
     role: { type: 'Role', isSingle: true },
@@ -2533,6 +2540,15 @@ decoders.MemberUpdatedEvent = (input?: Record<string, any>) => {
 decoders.MembersResponse = (input?: Record<string, any>) => {
   const typeMappings: TypeMapping = {
     members: { type: 'ChannelMember', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.MembershipLevelResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -4154,6 +4154,26 @@ export interface CreateImportURLResponse {
   upload_url: string;
 }
 
+export interface CreateMembershipLevelRequest {
+  id: string;
+
+  name: string;
+
+  description?: string;
+
+  priority?: number;
+
+  tags?: string[];
+
+  custom?: Record<string, any>;
+}
+
+export interface CreateMembershipLevelResponse {
+  duration: string;
+
+  membership_level: MembershipLevelResponse;
+}
+
 export interface CreatePollOptionRequest {
   text: string;
 
@@ -6924,6 +6944,24 @@ export interface MembersResponse {
   duration: string;
 
   members: ChannelMember[];
+}
+
+export interface MembershipLevelResponse {
+  created_at: Date;
+
+  id: string;
+
+  name: string;
+
+  priority: number;
+
+  updated_at: Date;
+
+  tags: string[];
+
+  description?: string;
+
+  custom?: Record<string, any>;
 }
 
 export interface Message {


### PR DESCRIPTION
This PR adds a new method and corresponding request/response types to support QA testing for the new endpoint. Code generated with yarn generate:open-api.
Link to task: https://linear.app/stream/issue/FEEDS-659/create-api-endpoint-to-create-membership-level
Link to PR in Go: https://github.com/GetStream/chat/pull/9549