### PR TITLE
Feeds main

### DIFF
--- a/src/StreamFeedsClient.ts
+++ b/src/StreamFeedsClient.ts
@@ -1,8 +1,13 @@
 import { FeedsApi } from './gen/feeds/FeedsApi';
+import { QueryFeedsRequest } from './gen/models';
 import { StreamFeed } from './StreamFeed';
 
 export class StreamFeedsClient extends FeedsApi {
   feed = (group: string, id: string) => {
     return new StreamFeed(this, group, id);
+  };
+
+  queryFeeds = (request: QueryFeedsRequest) => {
+    return super._queryFeeds(request);
   };
 }

--- a/src/gen/common/CommonApi.ts
+++ b/src/gen/common/CommonApi.ts
@@ -1335,6 +1335,7 @@ export class CommonApi {
       user_ids: request?.user_ids,
       calls: request?.calls,
       conversations: request?.conversations,
+      files: request?.files,
       messages: request?.messages,
       new_call_owner_id: request?.new_call_owner_id,
       new_channel_owner_id: request?.new_channel_owner_id,

--- a/src/gen/feeds/FeedApi.ts
+++ b/src/gen/feeds/FeedApi.ts
@@ -27,10 +27,13 @@ export class FeedApi {
     public readonly id: string,
   ) {}
 
-  delete(): Promise<StreamResponse<DeleteFeedResponse>> {
+  delete(request?: {
+    hard_delete?: boolean;
+  }): Promise<StreamResponse<DeleteFeedResponse>> {
     return this.feedsApi.deleteFeed({
       feed_id: this.id,
       feed_group_id: this.group,
+      ...request,
     });
   }
 

--- a/src/gen/feeds/FeedApi.ts
+++ b/src/gen/feeds/FeedApi.ts
@@ -27,13 +27,10 @@ export class FeedApi {
     public readonly id: string,
   ) {}
 
-  delete(request?: {
-    hard_delete?: boolean;
-  }): Promise<StreamResponse<DeleteFeedResponse>> {
+  delete(): Promise<StreamResponse<DeleteFeedResponse>> {
     return this.feedsApi.deleteFeed({
       feed_id: this.id,
       feed_group_id: this.group,
-      ...request,
     });
   }
 

--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -1009,7 +1009,7 @@ export class FeedsApi {
     request: CreateFeedGroupRequest,
   ): Promise<StreamResponse<CreateFeedGroupResponse>> {
     const body = {
-      feed_group_id: request?.feed_group_id,
+      id: request?.id,
       default_visibility: request?.default_visibility,
       activity_processors: request?.activity_processors,
       activity_selectors: request?.activity_selectors,
@@ -1378,20 +1378,32 @@ export class FeedsApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async deleteFeedGroup(): Promise<StreamResponse<DeleteFeedGroupResponse>> {
+  async deleteFeedGroup(request: {
+    id: string;
+  }): Promise<StreamResponse<DeleteFeedGroupResponse>> {
+    const pathParams = {
+      id: request?.id,
+    };
+
     const response = await this.apiClient.sendRequest<
       StreamResponse<DeleteFeedGroupResponse>
-    >('DELETE', '/api/v2/feeds/feed_groups/{id}', undefined, undefined);
+    >('DELETE', '/api/v2/feeds/feed_groups/{id}', pathParams, undefined);
 
     decoders.DeleteFeedGroupResponse?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
 
-  async getFeedGroup(): Promise<StreamResponse<GetFeedGroupResponse>> {
+  async getFeedGroup(request: {
+    id: string;
+  }): Promise<StreamResponse<GetFeedGroupResponse>> {
+    const pathParams = {
+      id: request?.id,
+    };
+
     const response = await this.apiClient.sendRequest<
       StreamResponse<GetFeedGroupResponse>
-    >('GET', '/api/v2/feeds/feed_groups/{id}', undefined, undefined);
+    >('GET', '/api/v2/feeds/feed_groups/{id}', pathParams, undefined);
 
     decoders.GetFeedGroupResponse?.(response.body);
 
@@ -1427,8 +1439,11 @@ export class FeedsApi {
   }
 
   async updateFeedGroup(
-    request?: UpdateFeedGroupRequest,
+    request: UpdateFeedGroupRequest & { id: string },
   ): Promise<StreamResponse<UpdateFeedGroupResponse>> {
+    const pathParams = {
+      id: request?.id,
+    };
     const body = {
       activity_processors: request?.activity_processors,
       activity_selectors: request?.activity_selectors,
@@ -1443,7 +1458,7 @@ export class FeedsApi {
     >(
       'PUT',
       '/api/v2/feeds/feed_groups/{id}',
-      undefined,
+      pathParams,
       undefined,
       body,
       'application/json',

--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -815,14 +815,18 @@ export class FeedsApi {
 
   async deleteComment(request: {
     id: string;
+    hard_delete?: boolean;
   }): Promise<StreamResponse<DeleteCommentResponse>> {
+    const queryParams = {
+      hard_delete: request?.hard_delete,
+    };
     const pathParams = {
       id: request?.id,
     };
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<DeleteCommentResponse>
-    >('DELETE', '/api/v2/feeds/comments/{id}', pathParams, undefined);
+    >('DELETE', '/api/v2/feeds/comments/{id}', pathParams, queryParams);
 
     decoders.DeleteCommentResponse?.(response.body);
 

--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -4,6 +4,8 @@ import {
   AcceptFeedMemberInviteResponse,
   AcceptFollowRequest,
   AcceptFollowResponse,
+  ActivityFeedbackRequest,
+  ActivityFeedbackResponse,
   AddActivityRequest,
   AddActivityResponse,
   AddBookmarkRequest,
@@ -38,6 +40,7 @@ import {
   ExportFeedUserDataResponse,
   FollowBatchRequest,
   FollowBatchResponse,
+  FollowRequest,
   GetActivityResponse,
   GetCommentRepliesResponse,
   GetCommentResponse,
@@ -45,12 +48,8 @@ import {
   GetFeedGroupResponse,
   GetFeedViewResponse,
   GetFollowSuggestionsResponse,
-  GetOrCreateFeedGroupRequest,
-  GetOrCreateFeedGroupResponse,
   GetOrCreateFeedRequest,
   GetOrCreateFeedResponse,
-  GetOrCreateFeedViewRequest,
-  GetOrCreateFeedViewResponse,
   ListFeedGroupsResponse,
   ListFeedViewsResponse,
   MarkActivityRequest,
@@ -80,7 +79,6 @@ import {
   RejectFollowRequest,
   RejectFollowResponse,
   Response,
-  SingleFollowRequest,
   SingleFollowResponse,
   UnfollowBatchRequest,
   UnfollowBatchResponse,
@@ -119,7 +117,7 @@ export class FeedsApi {
   ): Promise<StreamResponse<AddActivityResponse>> {
     const body = {
       type: request?.type,
-      fids: request?.fids,
+      feeds: request?.feeds,
       expires_at: request?.expires_at,
       id: request?.id,
       parent_id: request?.parent_id,
@@ -231,11 +229,7 @@ export class FeedsApi {
 
   async deleteActivity(request: {
     activity_id: string;
-    hard_delete?: boolean;
   }): Promise<StreamResponse<DeleteActivityResponse>> {
-    const queryParams = {
-      hard_delete: request?.hard_delete,
-    };
     const pathParams = {
       activity_id: request?.activity_id,
     };
@@ -246,7 +240,7 @@ export class FeedsApi {
       'DELETE',
       '/api/v2/feeds/activities/{activity_id}',
       pathParams,
-      queryParams,
+      undefined,
     );
 
     decoders.DeleteActivityResponse?.(response.body);
@@ -419,6 +413,38 @@ export class FeedsApi {
     );
 
     decoders.AddBookmarkResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async activityFeedback(
+    request: ActivityFeedbackRequest & { activity_id: string },
+  ): Promise<StreamResponse<ActivityFeedbackResponse>> {
+    const pathParams = {
+      activity_id: request?.activity_id,
+    };
+    const body = {
+      hide: request?.hide,
+      mute_user: request?.mute_user,
+      reason: request?.reason,
+      report: request?.report,
+      show_less: request?.show_less,
+      user_id: request?.user_id,
+      user: request?.user,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<ActivityFeedbackResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/activities/{activity_id}/feedback',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.ActivityFeedbackResponse?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -980,10 +1006,13 @@ export class FeedsApi {
   ): Promise<StreamResponse<CreateFeedGroupResponse>> {
     const body = {
       feed_group_id: request?.feed_group_id,
-      default_view_id: request?.default_view_id,
       default_visibility: request?.default_visibility,
+      activity_processors: request?.activity_processors,
+      activity_selectors: request?.activity_selectors,
+      aggregation: request?.aggregation,
       custom: request?.custom,
       notification: request?.notification,
+      ranking: request?.ranking,
     };
 
     const response = await this.apiClient.sendRequest<
@@ -1004,11 +1033,7 @@ export class FeedsApi {
 
   async deleteFeedGroup(request: {
     feed_group_id: string;
-    hard_delete?: boolean;
   }): Promise<StreamResponse<DeleteFeedGroupResponse>> {
-    const queryParams = {
-      hard_delete: request?.hard_delete,
-    };
     const pathParams = {
       feed_group_id: request?.feed_group_id,
     };
@@ -1019,7 +1044,7 @@ export class FeedsApi {
       'DELETE',
       '/api/v2/feeds/feed_groups/{feed_group_id}',
       pathParams,
-      queryParams,
+      undefined,
     );
 
     decoders.DeleteFeedGroupResponse?.(response.body);
@@ -1048,35 +1073,6 @@ export class FeedsApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async getOrCreateFeedGroup(
-    request: GetOrCreateFeedGroupRequest & { feed_group_id: string },
-  ): Promise<StreamResponse<GetOrCreateFeedGroupResponse>> {
-    const pathParams = {
-      feed_group_id: request?.feed_group_id,
-    };
-    const body = {
-      default_view_id: request?.default_view_id,
-      default_visibility: request?.default_visibility,
-      custom: request?.custom,
-      notification: request?.notification,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<GetOrCreateFeedGroupResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/feed_groups/{feed_group_id}',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.GetOrCreateFeedGroupResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
   async updateFeedGroup(
     request: UpdateFeedGroupRequest & { feed_group_id: string },
   ): Promise<StreamResponse<UpdateFeedGroupResponse>> {
@@ -1084,9 +1080,12 @@ export class FeedsApi {
       feed_group_id: request?.feed_group_id,
     };
     const body = {
-      default_view_id: request?.default_view_id,
+      activity_processors: request?.activity_processors,
+      activity_selectors: request?.activity_selectors,
+      aggregation: request?.aggregation,
       custom: request?.custom,
       notification: request?.notification,
+      ranking: request?.ranking,
     };
 
     const response = await this.apiClient.sendRequest<
@@ -1108,11 +1107,7 @@ export class FeedsApi {
   async deleteFeed(request: {
     feed_group_id: string;
     feed_id: string;
-    hard_delete?: boolean;
   }): Promise<StreamResponse<DeleteFeedResponse>> {
-    const queryParams = {
-      hard_delete: request?.hard_delete,
-    };
     const pathParams = {
       feed_group_id: request?.feed_group_id,
       feed_id: request?.feed_id,
@@ -1124,7 +1119,7 @@ export class FeedsApi {
       'DELETE',
       '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}',
       pathParams,
-      queryParams,
+      undefined,
     );
 
     decoders.DeleteFeedResponse?.(response.body);
@@ -1466,7 +1461,7 @@ export class FeedsApi {
     request: CreateFeedViewRequest,
   ): Promise<StreamResponse<CreateFeedViewResponse>> {
     const body = {
-      view_id: request?.view_id,
+      id: request?.id,
       activity_processors: request?.activity_processors,
       activity_selectors: request?.activity_selectors,
       aggregation: request?.aggregation,
@@ -1517,35 +1512,6 @@ export class FeedsApi {
     >('GET', '/api/v2/feeds/feed_views/{view_id}', pathParams, undefined);
 
     decoders.GetFeedViewResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async getOrCreateFeedView(
-    request: GetOrCreateFeedViewRequest & { view_id: string },
-  ): Promise<StreamResponse<GetOrCreateFeedViewResponse>> {
-    const pathParams = {
-      view_id: request?.view_id,
-    };
-    const body = {
-      activity_processors: request?.activity_processors,
-      activity_selectors: request?.activity_selectors,
-      aggregation: request?.aggregation,
-      ranking: request?.ranking,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<GetOrCreateFeedViewResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/feed_views/{view_id}',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.GetOrCreateFeedViewResponse?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1602,7 +1568,7 @@ export class FeedsApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async feedsQueryFeeds(
+  protected async _queryFeeds(
     request?: QueryFeedsRequest,
   ): Promise<StreamResponse<QueryFeedsResponse>> {
     const body = {
@@ -1659,7 +1625,7 @@ export class FeedsApi {
   }
 
   async follow(
-    request: SingleFollowRequest,
+    request: FollowRequest,
   ): Promise<StreamResponse<SingleFollowResponse>> {
     const body = {
       source: request?.source,

--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -1718,8 +1718,8 @@ export class FeedsApi {
     request: AcceptFollowRequest,
   ): Promise<StreamResponse<AcceptFollowResponse>> {
     const body = {
-      source_fid: request?.source_fid,
-      target_fid: request?.target_fid,
+      source: request?.source,
+      target: request?.target,
       follower_role: request?.follower_role,
     };
 
@@ -1793,8 +1793,8 @@ export class FeedsApi {
     request: RejectFollowRequest,
   ): Promise<StreamResponse<RejectFollowResponse>> {
     const body = {
-      source_fid: request?.source_fid,
-      target_fid: request?.target_fid,
+      source: request?.source,
+      target: request?.target,
     };
 
     const response = await this.apiClient.sendRequest<

--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -1035,104 +1035,6 @@ export class FeedsApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async deleteFeedGroup(request: {
-    feed_group_id: string;
-  }): Promise<StreamResponse<DeleteFeedGroupResponse>> {
-    const pathParams = {
-      feed_group_id: request?.feed_group_id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<DeleteFeedGroupResponse>
-    >(
-      'DELETE',
-      '/api/v2/feeds/feed_groups/{feed_group_id}',
-      pathParams,
-      undefined,
-    );
-
-    decoders.DeleteFeedGroupResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async getFeedGroup(request: {
-    feed_group_id: string;
-  }): Promise<StreamResponse<GetFeedGroupResponse>> {
-    const pathParams = {
-      feed_group_id: request?.feed_group_id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<GetFeedGroupResponse>
-    >(
-      'GET',
-      '/api/v2/feeds/feed_groups/{feed_group_id}',
-      pathParams,
-      undefined,
-    );
-
-    decoders.GetFeedGroupResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async getOrCreateFeedGroup(
-    request?: GetOrCreateFeedGroupRequest,
-  ): Promise<StreamResponse<GetOrCreateFeedGroupResponse>> {
-    const body = {
-      default_visibility: request?.default_visibility,
-      custom: request?.custom,
-      notification: request?.notification,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<GetOrCreateFeedGroupResponse>
-    >(
-      'POST',
-      '/api/v2/feeds/feed_groups/{feed_group_id}',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.GetOrCreateFeedGroupResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updateFeedGroup(
-    request: UpdateFeedGroupRequest & { feed_group_id: string },
-  ): Promise<StreamResponse<UpdateFeedGroupResponse>> {
-    const pathParams = {
-      feed_group_id: request?.feed_group_id,
-    };
-    const body = {
-      activity_processors: request?.activity_processors,
-      activity_selectors: request?.activity_selectors,
-      aggregation: request?.aggregation,
-      custom: request?.custom,
-      notification: request?.notification,
-      ranking: request?.ranking,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpdateFeedGroupResponse>
-    >(
-      'PUT',
-      '/api/v2/feeds/feed_groups/{feed_group_id}',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UpdateFeedGroupResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
   async deleteFeed(request: {
     feed_group_id: string;
     feed_id: string;
@@ -1472,6 +1374,82 @@ export class FeedsApi {
     );
 
     decoders.GetFollowSuggestionsResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deleteFeedGroup(): Promise<StreamResponse<DeleteFeedGroupResponse>> {
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<DeleteFeedGroupResponse>
+    >('DELETE', '/api/v2/feeds/feed_groups/{id}', undefined, undefined);
+
+    decoders.DeleteFeedGroupResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getFeedGroup(): Promise<StreamResponse<GetFeedGroupResponse>> {
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetFeedGroupResponse>
+    >('GET', '/api/v2/feeds/feed_groups/{id}', undefined, undefined);
+
+    decoders.GetFeedGroupResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getOrCreateFeedGroup(
+    request: GetOrCreateFeedGroupRequest & { id: string },
+  ): Promise<StreamResponse<GetOrCreateFeedGroupResponse>> {
+    const pathParams = {
+      id: request?.id,
+    };
+    const body = {
+      default_visibility: request?.default_visibility,
+      custom: request?.custom,
+      notification: request?.notification,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetOrCreateFeedGroupResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/feed_groups/{id}',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.GetOrCreateFeedGroupResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updateFeedGroup(
+    request?: UpdateFeedGroupRequest,
+  ): Promise<StreamResponse<UpdateFeedGroupResponse>> {
+    const body = {
+      activity_processors: request?.activity_processors,
+      activity_selectors: request?.activity_selectors,
+      aggregation: request?.aggregation,
+      custom: request?.custom,
+      notification: request?.notification,
+      ranking: request?.ranking,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpdateFeedGroupResponse>
+    >(
+      'PUT',
+      '/api/v2/feeds/feed_groups/{id}',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpdateFeedGroupResponse?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }

--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -1509,15 +1509,15 @@ export class FeedsApi {
   }
 
   async deleteFeedView(request: {
-    view_id: string;
+    id: string;
   }): Promise<StreamResponse<DeleteFeedViewResponse>> {
     const pathParams = {
-      view_id: request?.view_id,
+      id: request?.id,
     };
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<DeleteFeedViewResponse>
-    >('DELETE', '/api/v2/feeds/feed_views/{view_id}', pathParams, undefined);
+    >('DELETE', '/api/v2/feeds/feed_views/{id}', pathParams, undefined);
 
     decoders.DeleteFeedViewResponse?.(response.body);
 
@@ -1525,15 +1525,15 @@ export class FeedsApi {
   }
 
   async getFeedView(request: {
-    view_id: string;
+    id: string;
   }): Promise<StreamResponse<GetFeedViewResponse>> {
     const pathParams = {
-      view_id: request?.view_id,
+      id: request?.id,
     };
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<GetFeedViewResponse>
-    >('GET', '/api/v2/feeds/feed_views/{view_id}', pathParams, undefined);
+    >('GET', '/api/v2/feeds/feed_views/{id}', pathParams, undefined);
 
     decoders.GetFeedViewResponse?.(response.body);
 
@@ -1541,10 +1541,10 @@ export class FeedsApi {
   }
 
   async getOrCreateFeedView(
-    request: GetOrCreateFeedViewRequest & { view_id: string },
+    request: GetOrCreateFeedViewRequest & { id: string },
   ): Promise<StreamResponse<GetOrCreateFeedViewResponse>> {
     const pathParams = {
-      view_id: request?.view_id,
+      id: request?.id,
     };
     const body = {
       activity_processors: request?.activity_processors,
@@ -1557,7 +1557,7 @@ export class FeedsApi {
       StreamResponse<GetOrCreateFeedViewResponse>
     >(
       'POST',
-      '/api/v2/feeds/feed_views/{view_id}',
+      '/api/v2/feeds/feed_views/{id}',
       pathParams,
       undefined,
       body,
@@ -1570,10 +1570,10 @@ export class FeedsApi {
   }
 
   async updateFeedView(
-    request: UpdateFeedViewRequest & { view_id: string },
+    request: UpdateFeedViewRequest & { id: string },
   ): Promise<StreamResponse<UpdateFeedViewResponse>> {
     const pathParams = {
-      view_id: request?.view_id,
+      id: request?.id,
     };
     const body = {
       activity_processors: request?.activity_processors,
@@ -1586,7 +1586,7 @@ export class FeedsApi {
       StreamResponse<UpdateFeedViewResponse>
     >(
       'PUT',
-      '/api/v2/feeds/feed_views/{view_id}',
+      '/api/v2/feeds/feed_views/{id}',
       pathParams,
       undefined,
       body,

--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -48,8 +48,12 @@ import {
   GetFeedGroupResponse,
   GetFeedViewResponse,
   GetFollowSuggestionsResponse,
+  GetOrCreateFeedGroupRequest,
+  GetOrCreateFeedGroupResponse,
   GetOrCreateFeedRequest,
   GetOrCreateFeedResponse,
+  GetOrCreateFeedViewRequest,
+  GetOrCreateFeedViewResponse,
   ListFeedGroupsResponse,
   ListFeedViewsResponse,
   MarkActivityRequest,
@@ -1073,6 +1077,31 @@ export class FeedsApi {
     return { ...response.body, metadata: response.metadata };
   }
 
+  async getOrCreateFeedGroup(
+    request?: GetOrCreateFeedGroupRequest,
+  ): Promise<StreamResponse<GetOrCreateFeedGroupResponse>> {
+    const body = {
+      default_visibility: request?.default_visibility,
+      custom: request?.custom,
+      notification: request?.notification,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetOrCreateFeedGroupResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/feed_groups/{feed_group_id}',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.GetOrCreateFeedGroupResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
   async updateFeedGroup(
     request: UpdateFeedGroupRequest & { feed_group_id: string },
   ): Promise<StreamResponse<UpdateFeedGroupResponse>> {
@@ -1512,6 +1541,35 @@ export class FeedsApi {
     >('GET', '/api/v2/feeds/feed_views/{view_id}', pathParams, undefined);
 
     decoders.GetFeedViewResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getOrCreateFeedView(
+    request: GetOrCreateFeedViewRequest & { view_id: string },
+  ): Promise<StreamResponse<GetOrCreateFeedViewResponse>> {
+    const pathParams = {
+      view_id: request?.view_id,
+    };
+    const body = {
+      activity_processors: request?.activity_processors,
+      activity_selectors: request?.activity_selectors,
+      aggregation: request?.aggregation,
+      ranking: request?.ranking,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetOrCreateFeedViewResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/feed_views/{view_id}',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.GetOrCreateFeedViewResponse?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }

--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -1038,7 +1038,11 @@ export class FeedsApi {
   async deleteFeed(request: {
     feed_group_id: string;
     feed_id: string;
+    hard_delete?: boolean;
   }): Promise<StreamResponse<DeleteFeedResponse>> {
+    const queryParams = {
+      hard_delete: request?.hard_delete,
+    };
     const pathParams = {
       feed_group_id: request?.feed_group_id,
       feed_id: request?.feed_id,
@@ -1050,7 +1054,7 @@ export class FeedsApi {
       'DELETE',
       '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}',
       pathParams,
-      undefined,
+      queryParams,
     );
 
     decoders.DeleteFeedResponse?.(response.body);
@@ -1380,14 +1384,18 @@ export class FeedsApi {
 
   async deleteFeedGroup(request: {
     id: string;
+    hard_delete?: boolean;
   }): Promise<StreamResponse<DeleteFeedGroupResponse>> {
+    const queryParams = {
+      hard_delete: request?.hard_delete,
+    };
     const pathParams = {
       id: request?.id,
     };
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<DeleteFeedGroupResponse>
-    >('DELETE', '/api/v2/feeds/feed_groups/{id}', pathParams, undefined);
+    >('DELETE', '/api/v2/feeds/feed_groups/{id}', pathParams, queryParams);
 
     decoders.DeleteFeedGroupResponse?.(response.body);
 

--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -182,7 +182,7 @@ export class FeedsApi {
     request: DeleteActivitiesRequest,
   ): Promise<StreamResponse<DeleteActivitiesResponse>> {
     const body = {
-      activity_ids: request?.activity_ids,
+      ids: request?.ids,
       hard_delete: request?.hard_delete,
       user_id: request?.user_id,
       user: request?.user,

--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -233,7 +233,11 @@ export class FeedsApi {
 
   async deleteActivity(request: {
     activity_id: string;
+    hard_delete?: boolean;
   }): Promise<StreamResponse<DeleteActivityResponse>> {
+    const queryParams = {
+      hard_delete: request?.hard_delete,
+    };
     const pathParams = {
       activity_id: request?.activity_id,
     };
@@ -244,7 +248,7 @@ export class FeedsApi {
       'DELETE',
       '/api/v2/feeds/activities/{activity_id}',
       pathParams,
-      undefined,
+      queryParams,
     );
 
     decoders.DeleteActivityResponse?.(response.body);

--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -25,6 +25,8 @@ import {
   CreateFeedViewResponse,
   CreateFeedsBatchRequest,
   CreateFeedsBatchResponse,
+  CreateMembershipLevelRequest,
+  CreateMembershipLevelResponse,
   DeleteActivitiesRequest,
   DeleteActivitiesResponse,
   DeleteActivityReactionResponse,
@@ -1826,6 +1828,34 @@ export class FeedsApi {
     );
 
     decoders.UnfollowResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async createMembershipLevel(
+    request: CreateMembershipLevelRequest,
+  ): Promise<StreamResponse<CreateMembershipLevelResponse>> {
+    const body = {
+      id: request?.id,
+      name: request?.name,
+      description: request?.description,
+      priority: request?.priority,
+      tags: request?.tags,
+      custom: request?.custom,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<CreateMembershipLevelResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/membership_levels',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.CreateMembershipLevelResponse?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }

--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -819,15 +819,15 @@ export class FeedsApi {
   }
 
   async deleteComment(request: {
-    comment_id: string;
+    id: string;
   }): Promise<StreamResponse<DeleteCommentResponse>> {
     const pathParams = {
-      comment_id: request?.comment_id,
+      id: request?.id,
     };
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<DeleteCommentResponse>
-    >('DELETE', '/api/v2/feeds/comments/{comment_id}', pathParams, undefined);
+    >('DELETE', '/api/v2/feeds/comments/{id}', pathParams, undefined);
 
     decoders.DeleteCommentResponse?.(response.body);
 
@@ -835,15 +835,15 @@ export class FeedsApi {
   }
 
   async getComment(request: {
-    comment_id: string;
+    id: string;
   }): Promise<StreamResponse<GetCommentResponse>> {
     const pathParams = {
-      comment_id: request?.comment_id,
+      id: request?.id,
     };
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<GetCommentResponse>
-    >('GET', '/api/v2/feeds/comments/{comment_id}', pathParams, undefined);
+    >('GET', '/api/v2/feeds/comments/{id}', pathParams, undefined);
 
     decoders.GetCommentResponse?.(response.body);
 
@@ -851,10 +851,10 @@ export class FeedsApi {
   }
 
   async updateComment(
-    request: UpdateCommentRequest & { comment_id: string },
+    request: UpdateCommentRequest & { id: string },
   ): Promise<StreamResponse<UpdateCommentResponse>> {
     const pathParams = {
-      comment_id: request?.comment_id,
+      id: request?.id,
     };
     const body = {
       comment: request?.comment,
@@ -865,7 +865,7 @@ export class FeedsApi {
       StreamResponse<UpdateCommentResponse>
     >(
       'PATCH',
-      '/api/v2/feeds/comments/{comment_id}',
+      '/api/v2/feeds/comments/{id}',
       pathParams,
       undefined,
       body,
@@ -878,10 +878,10 @@ export class FeedsApi {
   }
 
   async addCommentReaction(
-    request: AddCommentReactionRequest & { comment_id: string },
+    request: AddCommentReactionRequest & { id: string },
   ): Promise<StreamResponse<AddCommentReactionResponse>> {
     const pathParams = {
-      comment_id: request?.comment_id,
+      id: request?.id,
     };
     const body = {
       type: request?.type,
@@ -895,7 +895,7 @@ export class FeedsApi {
       StreamResponse<AddCommentReactionResponse>
     >(
       'POST',
-      '/api/v2/feeds/comments/{comment_id}/reactions',
+      '/api/v2/feeds/comments/{id}/reactions',
       pathParams,
       undefined,
       body,
@@ -908,10 +908,10 @@ export class FeedsApi {
   }
 
   async queryCommentReactions(
-    request: QueryCommentReactionsRequest & { comment_id: string },
+    request: QueryCommentReactionsRequest & { id: string },
   ): Promise<StreamResponse<QueryCommentReactionsResponse>> {
     const pathParams = {
-      comment_id: request?.comment_id,
+      id: request?.id,
     };
     const body = {
       limit: request?.limit,
@@ -925,7 +925,7 @@ export class FeedsApi {
       StreamResponse<QueryCommentReactionsResponse>
     >(
       'POST',
-      '/api/v2/feeds/comments/{comment_id}/reactions/query',
+      '/api/v2/feeds/comments/{id}/reactions/query',
       pathParams,
       undefined,
       body,
@@ -938,7 +938,7 @@ export class FeedsApi {
   }
 
   async deleteCommentReaction(request: {
-    comment_id: string;
+    id: string;
     type: string;
     user_id?: string;
   }): Promise<StreamResponse<DeleteCommentReactionResponse>> {
@@ -946,7 +946,7 @@ export class FeedsApi {
       user_id: request?.user_id,
     };
     const pathParams = {
-      comment_id: request?.comment_id,
+      id: request?.id,
       type: request?.type,
     };
 
@@ -954,7 +954,7 @@ export class FeedsApi {
       StreamResponse<DeleteCommentReactionResponse>
     >(
       'DELETE',
-      '/api/v2/feeds/comments/{comment_id}/reactions/{type}',
+      '/api/v2/feeds/comments/{id}/reactions/{type}',
       pathParams,
       queryParams,
     );
@@ -965,7 +965,7 @@ export class FeedsApi {
   }
 
   async getCommentReplies(request: {
-    comment_id: string;
+    id: string;
     depth?: number;
     sort?: string;
     replies_limit?: number;
@@ -982,17 +982,12 @@ export class FeedsApi {
       next: request?.next,
     };
     const pathParams = {
-      comment_id: request?.comment_id,
+      id: request?.id,
     };
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<GetCommentRepliesResponse>
-    >(
-      'GET',
-      '/api/v2/feeds/comments/{comment_id}/replies',
-      pathParams,
-      queryParams,
-    );
+    >('GET', '/api/v2/feeds/comments/{id}/replies', pathParams, queryParams);
 
     decoders.GetCommentRepliesResponse?.(response.body);
 

--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -231,112 +231,6 @@ export class FeedsApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async deleteActivity(request: {
-    activity_id: string;
-    hard_delete?: boolean;
-  }): Promise<StreamResponse<DeleteActivityResponse>> {
-    const queryParams = {
-      hard_delete: request?.hard_delete,
-    };
-    const pathParams = {
-      activity_id: request?.activity_id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<DeleteActivityResponse>
-    >(
-      'DELETE',
-      '/api/v2/feeds/activities/{activity_id}',
-      pathParams,
-      queryParams,
-    );
-
-    decoders.DeleteActivityResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async getActivity(request: {
-    activity_id: string;
-  }): Promise<StreamResponse<GetActivityResponse>> {
-    const pathParams = {
-      activity_id: request?.activity_id,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<GetActivityResponse>
-    >('GET', '/api/v2/feeds/activities/{activity_id}', pathParams, undefined);
-
-    decoders.GetActivityResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updateActivityPartial(
-    request: UpdateActivityPartialRequest & { activity_id: string },
-  ): Promise<StreamResponse<UpdateActivityPartialResponse>> {
-    const pathParams = {
-      activity_id: request?.activity_id,
-    };
-    const body = {
-      user_id: request?.user_id,
-      unset: request?.unset,
-      set: request?.set,
-      user: request?.user,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpdateActivityPartialResponse>
-    >(
-      'PATCH',
-      '/api/v2/feeds/activities/{activity_id}',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UpdateActivityPartialResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updateActivity(
-    request: UpdateActivityRequest & { activity_id: string },
-  ): Promise<StreamResponse<UpdateActivityResponse>> {
-    const pathParams = {
-      activity_id: request?.activity_id,
-    };
-    const body = {
-      expires_at: request?.expires_at,
-      poll_id: request?.poll_id,
-      text: request?.text,
-      user_id: request?.user_id,
-      visibility: request?.visibility,
-      attachments: request?.attachments,
-      filter_tags: request?.filter_tags,
-      interest_tags: request?.interest_tags,
-      custom: request?.custom,
-      location: request?.location,
-      user: request?.user,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpdateActivityResponse>
-    >(
-      'PUT',
-      '/api/v2/feeds/activities/{activity_id}',
-      pathParams,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UpdateActivityResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
   async deleteBookmark(request: {
     activity_id: string;
     folder_id?: string;
@@ -598,6 +492,107 @@ export class FeedsApi {
     );
 
     decoders.DeleteActivityReactionResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deleteActivity(request: {
+    id: string;
+    hard_delete?: boolean;
+  }): Promise<StreamResponse<DeleteActivityResponse>> {
+    const queryParams = {
+      hard_delete: request?.hard_delete,
+    };
+    const pathParams = {
+      id: request?.id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<DeleteActivityResponse>
+    >('DELETE', '/api/v2/feeds/activities/{id}', pathParams, queryParams);
+
+    decoders.DeleteActivityResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getActivity(request: {
+    id: string;
+  }): Promise<StreamResponse<GetActivityResponse>> {
+    const pathParams = {
+      id: request?.id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetActivityResponse>
+    >('GET', '/api/v2/feeds/activities/{id}', pathParams, undefined);
+
+    decoders.GetActivityResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updateActivityPartial(
+    request: UpdateActivityPartialRequest & { id: string },
+  ): Promise<StreamResponse<UpdateActivityPartialResponse>> {
+    const pathParams = {
+      id: request?.id,
+    };
+    const body = {
+      user_id: request?.user_id,
+      unset: request?.unset,
+      set: request?.set,
+      user: request?.user,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpdateActivityPartialResponse>
+    >(
+      'PATCH',
+      '/api/v2/feeds/activities/{id}',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpdateActivityPartialResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updateActivity(
+    request: UpdateActivityRequest & { id: string },
+  ): Promise<StreamResponse<UpdateActivityResponse>> {
+    const pathParams = {
+      id: request?.id,
+    };
+    const body = {
+      expires_at: request?.expires_at,
+      poll_id: request?.poll_id,
+      text: request?.text,
+      user_id: request?.user_id,
+      visibility: request?.visibility,
+      attachments: request?.attachments,
+      filter_tags: request?.filter_tags,
+      interest_tags: request?.interest_tags,
+      custom: request?.custom,
+      location: request?.location,
+      user: request?.user,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpdateActivityResponse>
+    >(
+      'PUT',
+      '/api/v2/feeds/activities/{id}',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpdateActivityResponse?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }

--- a/src/gen/model-decoders/decoders.ts
+++ b/src/gen/model-decoders/decoders.ts
@@ -2275,6 +2275,13 @@ decoders.GetOrCreateCallResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
+decoders.GetOrCreateFeedGroupResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    feed_group: { type: 'FeedGroupResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
 decoders.GetOrCreateFeedResponse = (input?: Record<string, any>) => {
   const typeMappings: TypeMapping = {
     activities: { type: 'ActivityResponse', isSingle: false },
@@ -2299,6 +2306,13 @@ decoders.GetOrCreateFeedResponse = (input?: Record<string, any>) => {
     notification_status: { type: 'NotificationStatusResponse', isSingle: true },
 
     own_membership: { type: 'FeedMemberResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.GetOrCreateFeedViewResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    feed_view: { type: 'FeedViewResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
@@ -4240,6 +4254,17 @@ decoders.UserFlaggedEvent = (input?: Record<string, any>) => {
     created_at: { type: 'DatetimeType', isSingle: true },
 
     user: { type: 'User', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.UserMessagesDeletedEvent = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    user: { type: 'UserResponseCommonFields', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };

--- a/src/gen/model-decoders/decoders.ts
+++ b/src/gen/model-decoders/decoders.ts
@@ -1656,6 +1656,13 @@ decoders.CreateImportResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
+decoders.CreateMembershipLevelResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    membership_level: { type: 'MembershipLevelResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
 decoders.CreateRoleResponse = (input?: Record<string, any>) => {
   const typeMappings: TypeMapping = {
     role: { type: 'Role', isSingle: true },
@@ -2533,6 +2540,15 @@ decoders.MemberUpdatedEvent = (input?: Record<string, any>) => {
 decoders.MembersResponse = (input?: Record<string, any>) => {
   const typeMappings: TypeMapping = {
     members: { type: 'ChannelMember', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.MembershipLevelResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };

--- a/src/gen/model-decoders/decoders.ts
+++ b/src/gen/model-decoders/decoders.ts
@@ -1888,6 +1888,8 @@ decoders.FeedGroupResponse = (input?: Record<string, any>) => {
     created_at: { type: 'DatetimeType', isSingle: true },
 
     updated_at: { type: 'DatetimeType', isSingle: true },
+
+    activity_selectors: { type: 'ActivitySelectorConfig', isSingle: false },
   };
   return decode(typeMappings, input);
 };
@@ -2273,13 +2275,6 @@ decoders.GetOrCreateCallResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.GetOrCreateFeedGroupResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    feed_group: { type: 'FeedGroupResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
 decoders.GetOrCreateFeedResponse = (input?: Record<string, any>) => {
   const typeMappings: TypeMapping = {
     activities: { type: 'ActivityResponse', isSingle: false },
@@ -2304,13 +2299,6 @@ decoders.GetOrCreateFeedResponse = (input?: Record<string, any>) => {
     notification_status: { type: 'NotificationStatusResponse', isSingle: true },
 
     own_membership: { type: 'FeedMemberResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.GetOrCreateFeedViewResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    feed_view: { type: 'FeedViewResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -5484,33 +5484,29 @@ export interface FirebaseConfigFields {
 export interface Flag {
   created_at: Date;
 
-  entity_id: string;
-
-  entity_type: string;
+  created_by_automod: boolean;
 
   updated_at: Date;
 
-  result: Array<Record<string, any>>;
-
-  entity_creator_id?: string;
-
-  is_streamed_content?: boolean;
-
-  moderation_payload_hash?: string;
+  approved_at?: Date;
 
   reason?: string;
 
-  review_queue_item_id?: string;
+  rejected_at?: Date;
 
-  type?: string;
+  reviewed_at?: Date;
 
-  labels?: string[];
+  reviewed_by?: string;
+
+  target_message_id?: string;
 
   custom?: Record<string, any>;
 
-  moderation_payload?: ModerationPayload;
+  details?: FlagDetails;
 
-  review_queue_item?: ReviewQueueItem;
+  target_message?: Message;
+
+  target_user?: User;
 
   user?: User;
 }

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -4062,7 +4062,7 @@ export interface CreateExternalStorageResponse {
 }
 
 export interface CreateFeedGroupRequest {
-  feed_group_id: string;
+  id: string;
 
   default_visibility?:
     | 'public'

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -5153,11 +5153,9 @@ export interface FeedGroupDeletedEvent {
 export interface FeedGroupResponse {
   created_at: Date;
 
-  feed_group_id: string;
+  id: string;
 
   updated_at: Date;
-
-  default_view_id?: string;
 
   default_visibility?: string;
 
@@ -6143,6 +6141,27 @@ export interface GetOrCreateCallResponse {
   call: CallResponse;
 }
 
+export interface GetOrCreateFeedGroupRequest {
+  default_visibility?:
+    | 'public'
+    | 'visible'
+    | 'followers'
+    | 'members'
+    | 'private';
+
+  custom?: Record<string, any>;
+
+  notification?: NotificationConfig;
+}
+
+export interface GetOrCreateFeedGroupResponse {
+  duration: string;
+
+  was_created: boolean;
+
+  feed_group: FeedGroupResponse;
+}
+
 export interface GetOrCreateFeedRequest {
   limit?: number;
 
@@ -6211,6 +6230,24 @@ export interface GetOrCreateFeedResponse {
   notification_status?: NotificationStatusResponse;
 
   own_membership?: FeedMemberResponse;
+}
+
+export interface GetOrCreateFeedViewRequest {
+  activity_processors?: ActivityProcessorConfig[];
+
+  activity_selectors?: ActivitySelectorConfig[];
+
+  aggregation?: AggregationConfig;
+
+  ranking?: RankingConfig;
+}
+
+export interface GetOrCreateFeedViewResponse {
+  duration: string;
+
+  was_created: boolean;
+
+  feed_view: FeedViewResponse;
 }
 
 export interface GetPushTemplatesResponse {
@@ -12526,6 +12563,34 @@ export interface UserFlaggedEvent {
   user?: User;
 }
 
+export interface UserMessagesDeletedEvent {
+  created_at: Date;
+
+  hard_delete: boolean;
+
+  soft_delete: boolean;
+
+  custom: Record<string, any>;
+
+  user: UserResponseCommonFields;
+
+  type: string;
+
+  channel_id?: string;
+
+  channel_member_count?: number;
+
+  channel_type?: string;
+
+  cid?: string;
+
+  received_at?: Date;
+
+  team?: string;
+
+  channel_custom?: Record<string, any>;
+}
+
 export interface UserMute {
   created_at: Date;
 
@@ -13120,6 +13185,7 @@ export type WebhookEvent =
   | ({ type: 'user.deactivated' } & UserDeactivatedEvent)
   | ({ type: 'user.deleted' } & UserDeletedEvent)
   | ({ type: 'user.flagged' } & UserFlaggedEvent)
+  | ({ type: 'user.messages.deleted' } & UserMessagesDeletedEvent)
   | ({ type: 'user.muted' } & UserMutedEvent)
   | ({ type: 'user.reactivated' } & UserReactivatedEvent)
   | ({ type: 'user.unbanned' } & UserUnbannedEvent)

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -4154,6 +4154,26 @@ export interface CreateImportURLResponse {
   upload_url: string;
 }
 
+export interface CreateMembershipLevelRequest {
+  id: string;
+
+  name: string;
+
+  description?: string;
+
+  priority?: number;
+
+  tags?: string[];
+
+  custom?: Record<string, any>;
+}
+
+export interface CreateMembershipLevelResponse {
+  duration: string;
+
+  membership_level: MembershipLevelResponse;
+}
+
 export interface CreatePollOptionRequest {
   text: string;
 
@@ -6924,6 +6944,24 @@ export interface MembersResponse {
   duration: string;
 
   members: ChannelMember[];
+}
+
+export interface MembershipLevelResponse {
+  created_at: Date;
+
+  id: string;
+
+  name: string;
+
+  priority: number;
+
+  updated_at: Date;
+
+  tags: string[];
+
+  description?: string;
+
+  custom?: Record<string, any>;
 }
 
 export interface Message {

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -131,9 +131,9 @@ export interface AcceptFeedMemberInviteResponse {
 }
 
 export interface AcceptFollowRequest {
-  source_fid: string;
+  source: string;
 
-  target_fid: string;
+  target: string;
 
   follower_role?: string;
 }
@@ -5334,7 +5334,7 @@ export interface FeedResponse {
 
   description: string;
 
-  fid: string;
+  feed: string;
 
   follower_count: number;
 
@@ -5484,29 +5484,33 @@ export interface FirebaseConfigFields {
 export interface Flag {
   created_at: Date;
 
-  created_by_automod: boolean;
+  entity_id: string;
+
+  entity_type: string;
 
   updated_at: Date;
 
-  approved_at?: Date;
+  result: Array<Record<string, any>>;
+
+  entity_creator_id?: string;
+
+  is_streamed_content?: boolean;
+
+  moderation_payload_hash?: string;
 
   reason?: string;
 
-  rejected_at?: Date;
+  review_queue_item_id?: string;
 
-  reviewed_at?: Date;
+  type?: string;
 
-  reviewed_by?: string;
-
-  target_message_id?: string;
+  labels?: string[];
 
   custom?: Record<string, any>;
 
-  details?: FlagDetails;
+  moderation_payload?: ModerationPayload;
 
-  target_message?: Message;
-
-  target_user?: User;
+  review_queue_item?: ReviewQueueItem;
 
   user?: User;
 }
@@ -9753,9 +9757,9 @@ export interface RejectFeedMemberInviteResponse {
 }
 
 export interface RejectFollowRequest {
-  source_fid: string;
+  source: string;
 
-  target_fid: string;
+  target: string;
 }
 
 export interface RejectFollowResponse {

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -5384,7 +5384,7 @@ export interface FeedUpdatedEvent {
 }
 
 export interface FeedViewResponse {
-  view_id: string;
+  id: string;
 
   last_used_at?: Date;
 
@@ -5484,33 +5484,29 @@ export interface FirebaseConfigFields {
 export interface Flag {
   created_at: Date;
 
-  entity_id: string;
-
-  entity_type: string;
+  created_by_automod: boolean;
 
   updated_at: Date;
 
-  result: Array<Record<string, any>>;
-
-  entity_creator_id?: string;
-
-  is_streamed_content?: boolean;
-
-  moderation_payload_hash?: string;
+  approved_at?: Date;
 
   reason?: string;
 
-  review_queue_item_id?: string;
+  rejected_at?: Date;
 
-  type?: string;
+  reviewed_at?: Date;
 
-  labels?: string[];
+  reviewed_by?: string;
+
+  target_message_id?: string;
 
   custom?: Record<string, any>;
 
-  moderation_payload?: ModerationPayload;
+  details?: FlagDetails;
 
-  review_queue_item?: ReviewQueueItem;
+  target_message?: Message;
+
+  target_user?: User;
 
   user?: User;
 }

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -263,6 +263,8 @@ export interface ActivityAddedEvent {
 
   type: string;
 
+  feed_visibility?: string;
+
   received_at?: Date;
 
   user?: UserResponseCommonFields;
@@ -279,9 +281,35 @@ export interface ActivityDeletedEvent {
 
   type: string;
 
+  feed_visibility?: string;
+
   received_at?: Date;
 
   user?: UserResponseCommonFields;
+}
+
+export interface ActivityFeedbackRequest {
+  hide?: boolean;
+
+  mute_user?: boolean;
+
+  reason?: string;
+
+  report?: boolean;
+
+  show_less?: boolean;
+
+  user_id?: string;
+
+  user?: UserRequest;
+}
+
+export interface ActivityFeedbackResponse {
+  activity_id: string;
+
+  duration: string;
+
+  success: boolean;
 }
 
 export interface ActivityLocation {
@@ -298,6 +326,8 @@ export interface ActivityMarkEvent {
   custom: Record<string, any>;
 
   type: string;
+
+  feed_visibility?: string;
 
   mark_all_read?: boolean;
 
@@ -355,12 +385,16 @@ export interface ActivityPinnedEvent {
 
   type: string;
 
+  feed_visibility?: string;
+
   received_at?: Date;
 
   user?: UserResponseCommonFields;
 }
 
-export interface ActivityProcessorConfig {}
+export interface ActivityProcessorConfig {
+  type: string;
+}
 
 export interface ActivityReactionAddedEvent {
   created_at: Date;
@@ -374,6 +408,8 @@ export interface ActivityReactionAddedEvent {
   reaction: FeedsReactionResponse;
 
   type: string;
+
+  feed_visibility?: string;
 
   received_at?: Date;
 
@@ -393,6 +429,8 @@ export interface ActivityReactionDeletedEvent {
 
   type: string;
 
+  feed_visibility?: string;
+
   received_at?: Date;
 
   user?: UserResponseCommonFields;
@@ -411,6 +449,8 @@ export interface ActivityReactionUpdatedEvent {
 
   type: string;
 
+  feed_visibility?: string;
+
   received_at?: Date;
 
   user?: UserResponseCommonFields;
@@ -427,6 +467,8 @@ export interface ActivityRemovedFromFeedEvent {
 
   type: string;
 
+  feed_visibility?: string;
+
   received_at?: Date;
 
   user?: UserResponseCommonFields;
@@ -435,7 +477,7 @@ export interface ActivityRemovedFromFeedEvent {
 export interface ActivityRequest {
   type: string;
 
-  fids: string[];
+  feeds: string[];
 
   expires_at?: string;
 
@@ -523,6 +565,8 @@ export interface ActivityResponse {
 
   expires_at?: Date;
 
+  hidden?: boolean;
+
   text?: string;
 
   visibility_tag?: string;
@@ -563,6 +607,8 @@ export interface ActivityUnpinnedEvent {
 
   type: string;
 
+  feed_visibility?: string;
+
   received_at?: Date;
 
   user?: UserResponseCommonFields;
@@ -579,6 +625,8 @@ export interface ActivityUpdatedEvent {
 
   type: string;
 
+  feed_visibility?: string;
+
   received_at?: Date;
 
   user?: UserResponseCommonFields;
@@ -587,7 +635,7 @@ export interface ActivityUpdatedEvent {
 export interface AddActivityRequest {
   type: string;
 
-  fids: string[];
+  feeds: string[];
 
   expires_at?: string;
 
@@ -3554,6 +3602,8 @@ export interface CommentAddedEvent {
 
   type: string;
 
+  feed_visibility?: string;
+
   received_at?: Date;
 
   user?: UserResponseCommonFields;
@@ -3569,6 +3619,8 @@ export interface CommentDeletedEvent {
   custom: Record<string, any>;
 
   type: string;
+
+  feed_visibility?: string;
 
   received_at?: Date;
 
@@ -3588,6 +3640,8 @@ export interface CommentReactionAddedEvent {
 
   type: string;
 
+  feed_visibility?: string;
+
   received_at?: Date;
 
   user?: UserResponseCommonFields;
@@ -3606,6 +3660,8 @@ export interface CommentReactionDeletedEvent {
 
   type: string;
 
+  feed_visibility?: string;
+
   received_at?: Date;
 }
 
@@ -3621,6 +3677,8 @@ export interface CommentReactionUpdatedEvent {
   reaction: FeedsReactionResponse;
 
   type: string;
+
+  feed_visibility?: string;
 
   received_at?: Date;
 
@@ -3687,6 +3745,8 @@ export interface CommentUpdatedEvent {
   custom: Record<string, any>;
 
   type: string;
+
+  feed_visibility?: string;
 
   received_at?: Date;
 
@@ -4004,8 +4064,6 @@ export interface CreateExternalStorageResponse {
 export interface CreateFeedGroupRequest {
   feed_group_id: string;
 
-  default_view_id?: string;
-
   default_visibility?:
     | 'public'
     | 'visible'
@@ -4013,9 +4071,17 @@ export interface CreateFeedGroupRequest {
     | 'members'
     | 'private';
 
+  activity_processors?: ActivityProcessorConfig[];
+
+  activity_selectors?: ActivitySelectorConfig[];
+
+  aggregation?: AggregationConfig;
+
   custom?: Record<string, any>;
 
   notification?: NotificationConfig;
+
+  ranking?: RankingConfig;
 }
 
 export interface CreateFeedGroupResponse {
@@ -4025,7 +4091,7 @@ export interface CreateFeedGroupResponse {
 }
 
 export interface CreateFeedViewRequest {
-  view_id: string;
+  id: string;
 
   activity_processors?: ActivityProcessorConfig[];
 
@@ -4476,6 +4542,8 @@ export interface DeleteUsersRequest {
   calls?: 'soft' | 'hard';
 
   conversations?: 'soft' | 'hard';
+
+  files?: boolean;
 
   messages?: 'soft' | 'pruning' | 'hard';
 
@@ -4995,6 +5063,8 @@ export interface FeedCreatedEvent {
 
   type: string;
 
+  feed_visibility?: string;
+
   received_at?: Date;
 }
 
@@ -5007,17 +5077,19 @@ export interface FeedDeletedEvent {
 
   type: string;
 
+  feed_visibility?: string;
+
   received_at?: Date;
 
   user?: UserResponseCommonFields;
 }
 
 export interface FeedGroup {
+  aggregation_version: number;
+
   app_pk: number;
 
   created_at: Date;
-
-  default_view_id: string;
 
   default_visibility: string;
 
@@ -5025,13 +5097,21 @@ export interface FeedGroup {
 
   updated_at: Date;
 
+  activity_processors: ActivityProcessorConfig[];
+
+  activity_selectors: ActivitySelectorConfig[];
+
   custom: Record<string, any>;
 
   deleted_at?: Date;
 
   last_feed_get_at?: Date;
 
+  aggregation?: AggregationConfig;
+
   notification?: NotificationConfig;
+
+  ranking?: RankingConfig;
 
   stories?: StoriesConfig;
 }
@@ -5044,6 +5124,8 @@ export interface FeedGroupChangedEvent {
   custom: Record<string, any>;
 
   type: string;
+
+  feed_visibility?: string;
 
   received_at?: Date;
 
@@ -5063,13 +5145,15 @@ export interface FeedGroupDeletedEvent {
 
   type: string;
 
+  feed_visibility?: string;
+
   received_at?: Date;
 }
 
 export interface FeedGroupResponse {
   created_at: Date;
 
-  id: string;
+  feed_group_id: string;
 
   updated_at: Date;
 
@@ -5077,9 +5161,17 @@ export interface FeedGroupResponse {
 
   default_visibility?: string;
 
+  activity_processors?: ActivityProcessorConfig[];
+
+  activity_selectors?: ActivitySelectorConfig[];
+
+  aggregation?: AggregationConfig;
+
   custom?: Record<string, any>;
 
   notification?: NotificationConfig;
+
+  ranking?: RankingConfig;
 
   stories?: StoriesConfig;
 }
@@ -5109,6 +5201,8 @@ export interface FeedMemberAddedEvent {
 
   type: string;
 
+  feed_visibility?: string;
+
   received_at?: Date;
 
   user?: UserResponseCommonFields;
@@ -5125,6 +5219,8 @@ export interface FeedMemberRemovedEvent {
 
   type: string;
 
+  feed_visibility?: string;
+
   received_at?: Date;
 
   user?: UserResponseCommonFields;
@@ -5134,6 +5230,8 @@ export interface FeedMemberRequest {
   user_id: string;
 
   invite?: boolean;
+
+  membership_level?: string;
 
   role?: string;
 
@@ -5168,6 +5266,8 @@ export interface FeedMemberUpdatedEvent {
   member: FeedMemberResponse;
 
   type: string;
+
+  feed_visibility?: string;
 
   received_at?: Date;
 
@@ -5277,6 +5377,8 @@ export interface FeedUpdatedEvent {
   feed: FeedResponse;
 
   type: string;
+
+  feed_visibility?: string;
 
   received_at?: Date;
 
@@ -5510,6 +5612,8 @@ export interface FollowCreatedEvent {
 
   type: string;
 
+  feed_visibility?: string;
+
   received_at?: Date;
 }
 
@@ -5523,6 +5627,8 @@ export interface FollowDeletedEvent {
   follow: FollowResponse;
 
   type: string;
+
+  feed_visibility?: string;
 
   received_at?: Date;
 }
@@ -5577,6 +5683,8 @@ export interface FollowUpdatedEvent {
   follow: FollowResponse;
 
   type: string;
+
+  feed_visibility?: string;
 
   received_at?: Date;
 }
@@ -6035,29 +6143,6 @@ export interface GetOrCreateCallResponse {
   call: CallResponse;
 }
 
-export interface GetOrCreateFeedGroupRequest {
-  default_view_id?: string;
-
-  default_visibility?:
-    | 'public'
-    | 'visible'
-    | 'followers'
-    | 'members'
-    | 'private';
-
-  custom?: Record<string, any>;
-
-  notification?: NotificationConfig;
-}
-
-export interface GetOrCreateFeedGroupResponse {
-  duration: string;
-
-  was_created: boolean;
-
-  feed_group: FeedGroupResponse;
-}
-
 export interface GetOrCreateFeedRequest {
   limit?: number;
 
@@ -6126,24 +6211,6 @@ export interface GetOrCreateFeedResponse {
   notification_status?: NotificationStatusResponse;
 
   own_membership?: FeedMemberResponse;
-}
-
-export interface GetOrCreateFeedViewRequest {
-  activity_processors?: ActivityProcessorConfig[];
-
-  activity_selectors?: ActivitySelectorConfig[];
-
-  aggregation?: AggregationConfig;
-
-  ranking?: RankingConfig;
-}
-
-export interface GetOrCreateFeedViewResponse {
-  duration: string;
-
-  was_created: boolean;
-
-  feed_view: FeedViewResponse;
 }
 
 export interface GetPushTemplatesResponse {
@@ -7633,6 +7700,8 @@ export interface NotificationFeedUpdatedEvent {
 
   type: string;
 
+  feed_visibility?: string;
+
   received_at?: Date;
 
   aggregated_activities?: AggregatedActivityResponse[];
@@ -8021,7 +8090,7 @@ export interface PinActivityResponse {
 
   duration: string;
 
-  fid: string;
+  feed: string;
 
   user_id: string;
 
@@ -10500,18 +10569,6 @@ export interface ShowChannelResponse {
   duration: string;
 }
 
-export interface SingleFollowRequest {
-  source: string;
-
-  target: string;
-
-  create_notification_activity?: boolean;
-
-  push_preference?: 'all' | 'none';
-
-  custom?: Record<string, any>;
-}
-
 export interface SingleFollowResponse {
   duration: string;
 
@@ -11373,7 +11430,7 @@ export interface UnmuteResponse {
 export interface UnpinActivityResponse {
   duration: string;
 
-  fid: string;
+  feed: string;
 
   user_id: string;
 
@@ -11935,11 +11992,17 @@ export interface UpdateExternalStorageResponse {
 }
 
 export interface UpdateFeedGroupRequest {
-  default_view_id?: string;
+  activity_processors?: ActivityProcessorConfig[];
+
+  activity_selectors?: ActivitySelectorConfig[];
+
+  aggregation?: AggregationConfig;
 
   custom?: Record<string, any>;
 
   notification?: NotificationConfig;
+
+  ranking?: RankingConfig;
 }
 
 export interface UpdateFeedGroupResponse {

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -4355,7 +4355,7 @@ export interface DecayFunctionConfig {
 }
 
 export interface DeleteActivitiesRequest {
-  activity_ids: string[];
+  ids: string[];
 
   hard_delete?: boolean;
 
@@ -4367,7 +4367,7 @@ export interface DeleteActivitiesRequest {
 export interface DeleteActivitiesResponse {
   duration: string;
 
-  deleted_activity_ids: string[];
+  deleted_ids: string[];
 }
 
 export interface DeleteActivityReactionResponse {


### PR DESCRIPTION
## Breaking changes

### Models
- `AcceptFollowRequest`
  - `source_fid` renamed to `source`
  - `target_fid` renamed to `target`
- `ActivityRequest`
  - `fids` renamed to `feeds`  
- `ActivityResponse`
  - `object` renamed to `notification_context`
-  `AddActivityRequest`
  - `fids` renamed to `feeds`  
- `DeleteActivitiesRequest`
  - `activity_ids` renamed to `ids` 
- `DeleteActivitiesResponse`
  - `deleted_activity_ids` renamed to `deleted_ids`
- `FeedResponse`
  - `fid` renamed to `feed`
- `PinActivityResponse`
  - `fid` renamed to `feed`
- `RejectFollowRequest`
  - `source_fid` renamed to `source`
  - `target_fid` renamed to `target`
- `UnpinActivityResponse`
  - `fid` renamed to `feed`
- `SingleFollowRequest` model is removed, use `FollowRequest` instead (the fields are the same)

### API calls
- `deleteActivity`, `getActivity`, `updateActivityPartial`, `updateActivity` methods:
  - `activity_id` renamed to `id`
- `deleteComment`, `getComment`, `updateComment`, `addCommentReaction`, `queryCommentReactions`, `deleteCommentReaction`, `getCommentReplies` methods:
  - `comment_id` renamed to `id` 