### PR TITLE
feat: update membership level endpoint

### DIFF
--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -110,6 +110,8 @@ import {
   UpdateFeedViewResponse,
   UpdateFollowRequest,
   UpdateFollowResponse,
+  UpdateMembershipLevelRequest,
+  UpdateMembershipLevelResponse,
   UpsertActivitiesRequest,
   UpsertActivitiesResponse,
 } from '../models';
@@ -1860,6 +1862,36 @@ export class FeedsApi {
     );
 
     decoders.CreateMembershipLevelResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updateMembershipLevel(
+    request: UpdateMembershipLevelRequest & { id: string },
+  ): Promise<StreamResponse<UpdateMembershipLevelResponse>> {
+    const pathParams = {
+      id: request?.id,
+    };
+    const body = {
+      description: request?.description,
+      name: request?.name,
+      priority: request?.priority,
+      tags: request?.tags,
+      custom: request?.custom,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpdateMembershipLevelResponse>
+    >(
+      'PATCH',
+      '/api/v2/feeds/membership_levels/{id}',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpdateMembershipLevelResponse?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }

--- a/src/gen/model-decoders/decoders.ts
+++ b/src/gen/model-decoders/decoders.ts
@@ -4123,6 +4123,13 @@ decoders.UpdateMemberPartialResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
+decoders.UpdateMembershipLevelResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
+    membership_level: { type: 'MembershipLevelResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
 decoders.UpdateMessagePartialResponse = (input?: Record<string, any>) => {
   const typeMappings: TypeMapping = {
     message: { type: 'MessageResponse', isSingle: true },

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -12186,6 +12186,24 @@ export interface UpdateMemberPartialResponse {
   channel_member?: ChannelMemberResponse;
 }
 
+export interface UpdateMembershipLevelRequest {
+  description?: string;
+
+  name?: string;
+
+  priority?: number;
+
+  tags?: string[];
+
+  custom?: Record<string, any>;
+}
+
+export interface UpdateMembershipLevelResponse {
+  duration: string;
+
+  membership_level: MembershipLevelResponse;
+}
+
 export interface UpdateMessagePartialRequest {
   skip_enrich_url?: boolean;
 


### PR DESCRIPTION
Add a PATCH endpoint to allow updates to a membership level. Accept partial updates to any fields: name, description, tags,  priority and custom. Designed for server-side use only.

Endpoint:
PATCH /api/v2/feeds/membership_levels/{id}

[FEEDS-662](https://linear.app/stream/issue/FEEDS-662/create-api-endpoint-to-update-a-membership-level)