### PR TITLE
feat: [Feeds-661] delete membership level

### DIFF
--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -1897,6 +1897,25 @@ export class FeedsApi {
     return { ...response.body, metadata: response.metadata };
   }
 
+  async deleteMembershipLevel(request: {
+    id: string;
+  }): Promise<StreamResponse<Response>> {
+    const pathParams = {
+      id: request?.id,
+    };
+
+    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
+      'DELETE',
+      '/api/v2/feeds/membership_levels/{id}',
+      pathParams,
+      undefined,
+    );
+
+    decoders.Response?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
   async updateMembershipLevel(
     request: UpdateMembershipLevelRequest & { id: string },
   ): Promise<StreamResponse<UpdateMembershipLevelResponse>> {


### PR DESCRIPTION
Expose a server-side endpoint to delete a specific membership level by its UUID. This allows cleanup or user-level admin controls.

Endpoint:
DELETE /api/v2/feeds/membership_levels/{id}