### PR TITLE
fix: extend openai-realtime-api version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "uuid": "^9.0.1"
   },
   "peerDependencies": {
-    "@stream-io/openai-realtime-api": "~0.1.3"
+    "@stream-io/openai-realtime-api": "~0.1.3 || ~0.2.0 || ~0.3.0"
   },
   "peerDependenciesMeta": {
     "@stream-io/openai-realtime-api": {


### PR DESCRIPTION
### Overview

We have released a few semi-major versions of our openai-realtime wrapper, but our NodeSDK declares support for our `0.1.x` range only.