### PR TITLE
feat: update to version 193.9.1

### DIFF
--- a/__tests__/devices-push.test.ts
+++ b/__tests__/devices-push.test.ts
@@ -69,16 +69,6 @@ describe('devices and push', () => {
     expect(response).toBeDefined();
   });
 
-  // Wait for backend deployment
-  it.skip(`list push templates`, async () => {
-    const response = await client.getPushTemplates({
-      push_provider_type: 'firebase',
-      push_provider_name: 'firebase',
-    });
-
-    expect(response.templates).toBeDefined();
-  });
-
   // TODO: can't test delete because we can't upsert
   // it('delete push provider', async () => {
   //     const response = await client.deletePushProvider({name: pushProvider.push_provider!.name, type: DeletePushProviderTypeEnum.FIREBASE});

--- a/__tests__/devices-push.test.ts
+++ b/__tests__/devices-push.test.ts
@@ -69,6 +69,16 @@ describe('devices and push', () => {
     expect(response).toBeDefined();
   });
 
+  // Wait for backend deployment
+  it.skip(`list push templates`, async () => {
+    const response = await client.getPushTemplates({
+      push_provider_type: 'firebase',
+      push_provider_name: 'firebase',
+    });
+
+    expect(response.templates).toBeDefined();
+  });
+
   // TODO: can't test delete because we can't upsert
   // it('delete push provider', async () => {
   //     const response = await client.deletePushProvider({name: pushProvider.push_provider!.name, type: DeletePushProviderTypeEnum.FIREBASE});

--- a/src/gen/chat/ChatApi.ts
+++ b/src/gen/chat/ChatApi.ts
@@ -29,7 +29,6 @@ import {
   GetDraftResponse,
   GetManyMessagesResponse,
   GetMessageResponse,
-  GetPushTemplatesResponse,
   GetReactionsResponse,
   GetRepliesResponse,
   GetSegmentResponse,
@@ -114,10 +113,6 @@ import {
   UpdateReminderResponse,
   UpdateThreadPartialRequest,
   UpdateThreadPartialResponse,
-  UpsertPushPreferencesRequest,
-  UpsertPushPreferencesResponse,
-  UpsertPushTemplateRequest,
-  UpsertPushTemplateResponse,
   WrappedUnreadCountsResponse,
 } from '../models';
 import { decoders } from '../model-decoders/decoders';
@@ -1819,74 +1814,6 @@ export class ChatApi {
     );
 
     decoders.UnmuteResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async updatePushNotificationPreferences(
-    request: UpsertPushPreferencesRequest,
-  ): Promise<StreamResponse<UpsertPushPreferencesResponse>> {
-    const body = {
-      preferences: request?.preferences,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpsertPushPreferencesResponse>
-    >(
-      'POST',
-      '/api/v2/chat/push_preferences',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UpsertPushPreferencesResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async getPushTemplates(request: {
-    push_provider_type: string;
-    push_provider_name?: string;
-  }): Promise<StreamResponse<GetPushTemplatesResponse>> {
-    const queryParams = {
-      push_provider_type: request?.push_provider_type,
-      push_provider_name: request?.push_provider_name,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<GetPushTemplatesResponse>
-    >('GET', '/api/v2/chat/push_templates', undefined, queryParams);
-
-    decoders.GetPushTemplatesResponse?.(response.body);
-
-    return { ...response.body, metadata: response.metadata };
-  }
-
-  async upsertPushTemplate(
-    request: UpsertPushTemplateRequest,
-  ): Promise<StreamResponse<UpsertPushTemplateResponse>> {
-    const body = {
-      event_type: request?.event_type,
-      push_provider_type: request?.push_provider_type,
-      enable_push: request?.enable_push,
-      push_provider_name: request?.push_provider_name,
-      template: request?.template,
-    };
-
-    const response = await this.apiClient.sendRequest<
-      StreamResponse<UpsertPushTemplateResponse>
-    >(
-      'POST',
-      '/api/v2/chat/push_templates',
-      undefined,
-      undefined,
-      body,
-      'application/json',
-    );
-
-    decoders.UpsertPushTemplateResponse?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }

--- a/src/gen/common/CommonApi.ts
+++ b/src/gen/common/CommonApi.ts
@@ -42,6 +42,7 @@ import {
   GetCustomPermissionResponse,
   GetImportResponse,
   GetOGResponse,
+  GetPushTemplatesResponse,
   GetRateLimitsResponse,
   GetTaskResponse,
   ImageUploadRequest,
@@ -83,8 +84,12 @@ import {
   UpdateUsersPartialRequest,
   UpdateUsersRequest,
   UpdateUsersResponse,
+  UpsertPushPreferencesRequest,
+  UpsertPushPreferencesResponse,
   UpsertPushProviderRequest,
   UpsertPushProviderResponse,
+  UpsertPushTemplateRequest,
+  UpsertPushTemplateResponse,
 } from '../models';
 import { decoders } from '../model-decoders/decoders';
 
@@ -987,6 +992,29 @@ export class CommonApi {
     return { ...response.body, metadata: response.metadata };
   }
 
+  async updatePushNotificationPreferences(
+    request: UpsertPushPreferencesRequest,
+  ): Promise<StreamResponse<UpsertPushPreferencesResponse>> {
+    const body = {
+      preferences: request?.preferences,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpsertPushPreferencesResponse>
+    >(
+      'POST',
+      '/api/v2/push_preferences',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpsertPushPreferencesResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
   async listPushProviders(): Promise<
     StreamResponse<ListPushProvidersResponse>
   > {
@@ -1039,6 +1067,51 @@ export class CommonApi {
     );
 
     decoders.Response?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getPushTemplates(request: {
+    push_provider_type: string;
+    push_provider_name?: string;
+  }): Promise<StreamResponse<GetPushTemplatesResponse>> {
+    const queryParams = {
+      push_provider_type: request?.push_provider_type,
+      push_provider_name: request?.push_provider_name,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetPushTemplatesResponse>
+    >('GET', '/api/v2/push_templates', undefined, queryParams);
+
+    decoders.GetPushTemplatesResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async upsertPushTemplate(
+    request: UpsertPushTemplateRequest,
+  ): Promise<StreamResponse<UpsertPushTemplateResponse>> {
+    const body = {
+      event_type: request?.event_type,
+      push_provider_type: request?.push_provider_type,
+      enable_push: request?.enable_push,
+      push_provider_name: request?.push_provider_name,
+      template: request?.template,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpsertPushTemplateResponse>
+    >(
+      'POST',
+      '/api/v2/push_templates',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.UpsertPushTemplateResponse?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }

--- a/src/gen/model-decoders/decoders.ts
+++ b/src/gen/model-decoders/decoders.ts
@@ -2687,6 +2687,8 @@ decoders.MessageReadEvent = (input?: Record<string, any>) => {
 
     channel_last_message_at: { type: 'DatetimeType', isSingle: true },
 
+    channel: { type: 'ChannelResponse', isSingle: true },
+
     thread: { type: 'ThreadResponse', isSingle: true },
 
     user: { type: 'UserResponseCommonFields', isSingle: true },

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -1968,6 +1968,8 @@ export interface CallParticipant {
 
   role: string;
 
+  role: string;
+
   user_session_id: string;
 
   custom: Record<string, any>;
@@ -2315,6 +2317,8 @@ export interface CallSessionParticipantLeftEvent {
   participant: CallParticipantResponse;
 
   type: string;
+
+  reason?: string;
 }
 
 export interface CallSessionResponse {
@@ -4507,8 +4511,6 @@ export interface DeleteFeedGroupResponse {
 }
 
 export interface DeleteFeedResponse {
-  delete_feed_task_id: string;
-
   duration: string;
 
   task_id: string;
@@ -5466,15 +5468,15 @@ export interface FeedsModerationTemplateConfig {
 }
 
 export interface FeedsPreferences {
-  comment?: string;
+  comment?: 'all' | 'none';
 
-  comment_reaction?: string;
+  comment_reaction?: 'all' | 'none';
 
-  follow?: string;
+  follow?: 'all' | 'none';
 
-  mention?: string;
+  mention?: 'all' | 'none';
 
-  reaction?: string;
+  reaction?: 'all' | 'none';
 
   custom_activity_types?: Record<string, string>;
 }
@@ -7371,6 +7373,8 @@ export interface MessageReadEvent {
   last_read_message_id?: string;
 
   team?: string;
+
+  channel?: ChannelResponse;
 
   thread?: ThreadResponse;
 
@@ -12818,7 +12822,7 @@ export interface UpsertPushPreferencesResponse {
 
   user_channel_preferences: Record<
     string,
-    Record<string, ChannelPushPreferences>
+    Record<string, ChannelPushPreferences | null>
   >;
 
   user_preferences: Record<string, PushPreferences>;

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -1968,8 +1968,6 @@ export interface CallParticipant {
 
   role: string;
 
-  role: string;
-
   user_session_id: string;
 
   custom: Record<string, any>;

--- a/src/gen/video/VideoApi.ts
+++ b/src/gen/video/VideoApi.ts
@@ -791,6 +791,7 @@ export class VideoApi {
       enable_transcription: request?.enable_transcription,
       external_storage: request?.external_storage,
       language: request?.language,
+      speech_segment_config: request?.speech_segment_config,
     };
 
     const response = await this.apiClient.sendRequest<


### PR DESCRIPTION
BREAKING CHANGES:

Push config methods moved from `client.chat` to `client`
```
// Old syntax
client.chat.updatePushNotificationPreferences

// New syntax
client.updatePushNotificationPreferences

// Old syntax
client.chat.getPushTemplates

// New syntax
client.getPushTemplates

// Old syntax
client.chat.upsertPushTemplate

// New syntax
client.upsertPushTemplate
```