### PR TITLE
feat: change cutoff_time in feed group/view request to be string, and on response to be time or omitted

### DIFF
--- a/src/gen/model-decoders/decoders.ts
+++ b/src/gen/model-decoders/decoders.ts
@@ -226,6 +226,13 @@ decoders.ActivityResponse = (input?: Record<string, any>) => {
 
 decoders.ActivitySelectorConfig = (input?: Record<string, any>) => {
   const typeMappings: TypeMapping = {
+    cutoff_time: { type: 'StringType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.ActivitySelectorConfigResponse = (input?: Record<string, any>) => {
+  const typeMappings: TypeMapping = {
     cutoff_time: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
@@ -1903,7 +1910,10 @@ decoders.FeedGroupResponse = (input?: Record<string, any>) => {
 
     updated_at: { type: 'DatetimeType', isSingle: true },
 
-    activity_selectors: { type: 'ActivitySelectorConfig', isSingle: false },
+    activity_selectors: {
+      type: 'ActivitySelectorConfigResponse',
+      isSingle: false,
+    },
   };
   return decode(typeMappings, input);
 };
@@ -1996,7 +2006,10 @@ decoders.FeedViewResponse = (input?: Record<string, any>) => {
   const typeMappings: TypeMapping = {
     last_used_at: { type: 'DatetimeType', isSingle: true },
 
-    activity_selectors: { type: 'ActivitySelectorConfig', isSingle: false },
+    activity_selectors: {
+      type: 'ActivitySelectorConfigResponse',
+      isSingle: false,
+    },
   };
   return decode(typeMappings, input);
 };

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -595,6 +595,18 @@ export interface ActivityResponse {
 }
 
 export interface ActivitySelectorConfig {
+  cutoff_time?: string;
+
+  min_popularity?: number;
+
+  type?: string;
+
+  sort?: SortParam[];
+
+  filter?: Record<string, any>;
+}
+
+export interface ActivitySelectorConfigResponse {
   cutoff_time?: Date;
 
   min_popularity?: number;
@@ -5257,7 +5269,7 @@ export interface FeedGroupResponse {
 
   activity_processors?: ActivityProcessorConfig[];
 
-  activity_selectors?: ActivitySelectorConfig[];
+  activity_selectors?: ActivitySelectorConfigResponse[];
 
   aggregation?: AggregationConfig;
 
@@ -5493,7 +5505,7 @@ export interface FeedViewResponse {
 
   activity_processors?: ActivityProcessorConfig[];
 
-  activity_selectors?: ActivitySelectorConfig[];
+  activity_selectors?: ActivitySelectorConfigResponse[];
 
   aggregation?: AggregationConfig;
 


### PR DESCRIPTION
[[FEEDS-738]](https://linear.app/stream/issue/FEEDS-738/cutoff-typing-is-wrong-in-activityselectorconfig)
change cutoff_time in feed group/view request to be string, and on response to be time or omitted