### PR TITLE
feat: change cutoff_time in feed group/view request to be string, and on …

### DIFF
--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -80,6 +80,8 @@ import {
   QueryFeedMembersResponse,
   QueryFeedsRequest,
   QueryFeedsResponse,
+  QueryFeedsUsageStatsRequest,
+  QueryFeedsUsageStatsResponse,
   QueryFollowsRequest,
   QueryFollowsResponse,
   QueryMembershipLevelsRequest,
@@ -341,6 +343,7 @@ export class FeedsApi {
       reason: request?.reason,
       report: request?.report,
       show_less: request?.show_less,
+      show_more: request?.show_more,
       user_id: request?.user_id,
       user: request?.user,
     };
@@ -2024,6 +2027,30 @@ export class FeedsApi {
     );
 
     decoders.UpdateMembershipLevelResponse?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async queryFeedsUsageStats(
+    request?: QueryFeedsUsageStatsRequest,
+  ): Promise<StreamResponse<QueryFeedsUsageStatsResponse>> {
+    const body = {
+      from: request?.from,
+      to: request?.to,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<QueryFeedsUsageStatsResponse>
+    >(
+      'POST',
+      '/api/v2/feeds/stats/usage',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders.QueryFeedsUsageStatsResponse?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }

--- a/src/gen/model-decoders/decoders.ts
+++ b/src/gen/model-decoders/decoders.ts
@@ -224,7 +224,7 @@ decoders.ActivityResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ActivitySelectorConfig = (input?: Record<string, any>) => {
+decoders.ActivitySelectorConfigResponse = (input?: Record<string, any>) => {
   const typeMappings: TypeMapping = {
     cutoff_time: { type: 'DatetimeType', isSingle: true },
   };
@@ -1903,9 +1903,10 @@ decoders.FeedGroupResponse = (input?: Record<string, any>) => {
 
     updated_at: { type: 'DatetimeType', isSingle: true },
 
-    deleted_at: { type: 'DatetimeType', isSingle: true },
-
-    activity_selectors: { type: 'ActivitySelectorConfig', isSingle: false },
+    activity_selectors: {
+      type: 'ActivitySelectorConfigResponse',
+      isSingle: false,
+    },
   };
   return decode(typeMappings, input);
 };
@@ -1998,7 +1999,10 @@ decoders.FeedViewResponse = (input?: Record<string, any>) => {
   const typeMappings: TypeMapping = {
     last_used_at: { type: 'DatetimeType', isSingle: true },
 
-    activity_selectors: { type: 'ActivitySelectorConfig', isSingle: false },
+    activity_selectors: {
+      type: 'ActivitySelectorConfigResponse',
+      isSingle: false,
+    },
   };
   return decode(typeMappings, input);
 };
@@ -3273,6 +3277,28 @@ decoders.QueryCallParticipantsResponse = (input?: Record<string, any>) => {
     participants: { type: 'CallParticipantResponse', isSingle: false },
 
     call: { type: 'CallResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.QueryCallSessionParticipantStatsResponse = (
+  input?: Record<string, any>,
+) => {
+  const typeMappings: TypeMapping = {
+    participants: { type: 'CallStatsParticipant', isSingle: false },
+
+    call_ended_at: { type: 'DatetimeType', isSingle: true },
+
+    call_started_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders.QueryCallSessionParticipantStatsTimelineResponse = (
+  input?: Record<string, any>,
+) => {
+  const typeMappings: TypeMapping = {
+    events: { type: 'CallParticipantTimeline', isSingle: false },
   };
   return decode(typeMappings, input);
 };

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -311,6 +311,8 @@ export interface ActivityFeedbackRequest {
 
   show_less?: boolean;
 
+  show_more?: boolean;
+
   user_id?: string;
 
   user?: UserRequest;
@@ -597,6 +599,18 @@ export interface ActivityResponse {
 }
 
 export interface ActivitySelectorConfig {
+  cutoff_time?: Date;
+
+  min_popularity?: number;
+
+  type?: string;
+
+  sort?: SortParam[];
+
+  filter?: Record<string, any>;
+}
+
+export interface ActivitySelectorConfigResponse {
   cutoff_time?: Date;
 
   min_popularity?: number;
@@ -4394,6 +4408,18 @@ export interface DailyAggregateUserFeedbackReportResponse {
   report: UserFeedbackReport;
 }
 
+export interface DailyMetricResponse {
+  date: string;
+
+  value: number;
+}
+
+export interface DailyMetricStatsResponse {
+  total: number;
+
+  daily: DailyMetricResponse[];
+}
+
 export interface Data {
   id: string;
 }
@@ -5507,7 +5533,7 @@ export interface FeedViewResponse {
 
   activity_processors?: ActivityProcessorConfig[];
 
-  activity_selectors?: ActivitySelectorConfig[];
+  activity_selectors?: ActivitySelectorConfigResponse[];
 
   aggregation?: AggregationConfig;
 
@@ -9398,6 +9424,22 @@ export interface QueryFeedsResponse {
   next?: string;
 
   prev?: string;
+}
+
+export interface QueryFeedsUsageStatsRequest {
+  from?: string;
+
+  to?: string;
+}
+
+export interface QueryFeedsUsageStatsResponse {
+  duration: string;
+
+  activities: DailyMetricStatsResponse;
+
+  api_requests: DailyMetricStatsResponse;
+
+  follows: DailyMetricStatsResponse;
 }
 
 export interface QueryFollowsRequest {


### PR DESCRIPTION
- change cutoff_time in feed group/view request to be string, and on response to be time or omitted

- add feeds usage stats endpoints