### PR TITLE
chore: allow @stream-io/openai-realtime-api ~0.4.0 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "uuid": "^13.0.0"
   },
   "peerDependencies": {
-    "@stream-io/openai-realtime-api": "~0.1.3 || ~0.2.0 || ~0.3.0 || ~0.3.3"
+    "@stream-io/openai-realtime-api": "~0.1.3 || ~0.2.0 || ~0.3.0 || ~0.4.0"
   },
   "peerDependenciesMeta": {
     "@stream-io/openai-realtime-api": {


### PR DESCRIPTION
## Summary

Widens the `@stream-io/openai-realtime-api` peer dependency range to also allow `~0.4.0`.

```diff
- "@stream-io/openai-realtime-api": "~0.1.3 || ~0.2.0 || ~0.3.0 || ~0.3.3"
+ "@stream-io/openai-realtime-api": "~0.1.3 || ~0.2.0 || ~0.3.0 || ~0.4.0"
```

This lets consumers on the latest `0.4.x` release of `@stream-io/openai-realtime-api` install `@stream-io/node-sdk` without a peer-dependency conflict.

## Notes
- Peer-dependency range change only; no runtime/source code is affected.