### PR TITLE
feat: update to open api version 233.25.1

### DIFF
--- a/src/gen/chat/ChannelApi.ts
+++ b/src/gen/chat/ChannelApi.ts
@@ -259,6 +259,7 @@ export class ChannelApi {
 
   getManyMessages(request: {
     ids: string[];
+    member_custom_include?: string[];
   }): Promise<StreamResponse<GetManyMessagesResponse>> {
     if (!this.id) {
       throw new Error(

--- a/src/gen/chat/ChatApi.ts
+++ b/src/gen/chat/ChatApi.ts
@@ -353,6 +353,7 @@ export class ChatApi {
       predefined_filter: request?.predefined_filter,
       state: request?.state,
       user_id: request?.user_id,
+      member_custom_include: request?.member_custom_include,
       sort: request?.sort,
       filter_conditions: request?.filter_conditions,
       filter_values: request?.filter_values,
@@ -513,6 +514,7 @@ export class ChatApi {
       hide_for_creator: request?.hide_for_creator,
       state: request?.state,
       thread_unread_counts: request?.thread_unread_counts,
+      member_custom_include: request?.member_custom_include,
       data: request?.data,
       members: request?.members,
       messages: request?.messages,
@@ -950,9 +952,11 @@ export class ChatApi {
     type: string;
     id: string;
     ids: string[];
+    member_custom_include?: string[];
   }): Promise<StreamResponse<GetManyMessagesResponse>> {
     const queryParams = {
       ids: request?.ids,
+      member_custom_include: request?.member_custom_include,
     };
     const pathParams = {
       type: request?.type,
@@ -984,6 +988,7 @@ export class ChatApi {
       hide_for_creator: request?.hide_for_creator,
       state: request?.state,
       thread_unread_counts: request?.thread_unread_counts,
+      member_custom_include: request?.member_custom_include,
       data: request?.data,
       members: request?.members,
       messages: request?.messages,
@@ -1979,6 +1984,7 @@ export class ChatApi {
     id_lt?: string;
     id_around?: string;
     sort?: SortParamRequest[];
+    member_custom_include?: string[];
   }): Promise<StreamResponse<GetRepliesResponse>> {
     const queryParams = {
       limit: request?.limit,
@@ -1988,6 +1994,7 @@ export class ChatApi {
       id_lt: request?.id_lt,
       id_around: request?.id_around,
       sort: request?.sort,
+      member_custom_include: request?.member_custom_include,
     };
     const pathParams = {
       parent_id: request?.parent_id,

--- a/src/gen/common/CommonApi.ts
+++ b/src/gen/common/CommonApi.ts
@@ -239,6 +239,8 @@ export class CommonApi {
       is_substring_matching_enabled: request?.is_substring_matching_enabled,
       team: request?.team,
       type: request?.type,
+      user_id: request?.user_id,
+      user: request?.user,
     };
 
     const response = await this.apiClient.sendRequest<
@@ -287,9 +289,11 @@ export class CommonApi {
   async deleteBlockList(request: {
     name: string;
     team?: string;
+    user_id?: string;
   }): Promise<StreamResponse<Response>> {
     const queryParams = {
       team: request?.team,
+      user_id: request?.user_id,
     };
     const pathParams = {
       name: request?.name,
@@ -339,7 +343,9 @@ export class CommonApi {
       is_plural_check_enabled: request?.is_plural_check_enabled,
       is_substring_matching_enabled: request?.is_substring_matching_enabled,
       team: request?.team,
+      user_id: request?.user_id,
       words: request?.words,
+      user: request?.user,
     };
 
     const response = await this.apiClient.sendRequest<
@@ -1284,6 +1290,7 @@ export class CommonApi {
     android?: boolean;
     ios?: boolean;
     web?: boolean;
+    unity?: boolean;
     endpoints?: string;
   }): Promise<StreamResponse<GetRateLimitsResponse>> {
     const queryParams = {
@@ -1291,6 +1298,7 @@ export class CommonApi {
       android: request?.android,
       ios: request?.ios,
       web: request?.web,
+      unity: request?.unity,
       endpoints: request?.endpoints,
     };
 

--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -2600,6 +2600,7 @@ export class FeedsApi {
     android?: boolean;
     ios?: boolean;
     web?: boolean;
+    unity?: boolean;
     server_side?: boolean;
   }): Promise<StreamResponse<GetFeedsRateLimitsResponse>> {
     const queryParams = {
@@ -2607,6 +2608,7 @@ export class FeedsApi {
       android: request?.android,
       ios: request?.ios,
       web: request?.web,
+      unity: request?.unity,
       server_side: request?.server_side,
     };
 

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -5449,6 +5449,11 @@ export interface ChannelGetOrCreateRequest {
 
   thread_unread_counts?: boolean;
 
+  /**
+   * Top-level keys of the message sender's channel-member custom data to include under member.custom (max 8 keys, 64 chars each)
+   */
+  member_custom_include?: string[];
+
   data?: ChannelInput;
 
   members?: PaginationParams;
@@ -5584,6 +5589,11 @@ export interface ChannelMemberPartialResponse {
    * Whether the user muted notifications for this channel
    */
   notifications_muted: boolean;
+
+  /**
+   * Channel-member custom fields projected via `member_custom_include`
+   */
+  custom?: Record<string, any>;
 }
 
 export interface ChannelMemberRequest {
@@ -7695,6 +7705,10 @@ export interface CreateBlockListRequest {
     | 'email'
     | 'email_allowlist'
     | 'word';
+
+  user_id?: string;
+
+  user?: UserRequest;
 }
 
 export interface CreateBlockListResponse {
@@ -8412,6 +8426,9 @@ export interface CreatePollOptionRequest {
 
   user_id?: string;
 
+  /**
+   * Custom data for this object
+   */
   custom?: Record<string, any>;
 
   user?: UserRequest;
@@ -8458,6 +8475,9 @@ export interface CreatePollRequest {
 
   options?: PollOptionInput[];
 
+  /**
+   * Custom data for this object
+   */
   custom?: Record<string, any>;
 
   user?: UserRequest;
@@ -9293,6 +9313,39 @@ export interface DeleteTranscriptionResponse {
   duration: string;
 }
 
+export interface DeleteUserMessagesRequestPayload {
+  /**
+   * Message deletion mode: soft, pruning, or hard
+   */
+
+  delete_messages: 'soft' | 'pruning' | 'hard';
+
+  /**
+   * Optional: scope deletion to a single channel (alternative to app-wide deletion)
+   */
+  channel_cid?: string;
+
+  /**
+   * Whether to also delete the user's reactions on other users' messages
+   */
+  delete_reactions?: boolean;
+
+  /**
+   * ID of the user whose messages should be deleted (alternative to item_id)
+   */
+  entity_id?: string;
+
+  /**
+   * Type of the entity
+   */
+  entity_type?: string;
+
+  /**
+   * Reason for the deletion
+   */
+  reason?: string;
+}
+
 export interface DeleteUserRequestPayload {
   /**
    * Also delete all user conversations
@@ -9620,16 +9673,18 @@ export interface EgressResponse {
 
 export interface EncryptionSettingsRequest {
   /**
-   * if true, the call is created end-to-end encrypted
+   * Encryption mode. One of: available, disabled, auto-on
    */
-  enabled?: boolean;
+
+  mode?: 'available' | 'disabled' | 'auto-on';
 }
 
 export interface EncryptionSettingsResponse {
   /**
-   * whether the call is end-to-end encrypted
+   * the resolved encryption mode for the call
    */
-  enabled: boolean;
+
+  mode: 'available' | 'disabled' | 'auto-on';
 }
 
 export interface EndCallRequest {}
@@ -11360,6 +11415,11 @@ export interface FilterConfigResponse {
    * The moderation_payload.custom keys the app has configured as review-queue filter chips (via moderation_dashboard_preferences.filterable_custom_keys). Discovery hint for the dashboard only — the filter accepts any custom key regardless of this list.
    */
   filterable_custom_keys?: string[];
+
+  /**
+   * AI image moderation labels available as filter values, as a map of L1 label to its L2 sub-labels. Reflects the app's effective image taxonomy: custom Bodyguard taxonomy when enabled, otherwise the standard catalogue of the org's enabled image providers.
+   */
+  ai_image_taxonomy?: Record<string, string[]>;
 }
 
 export interface FirebaseConfig {
@@ -11519,6 +11579,8 @@ export interface FlagUserOptions {
 }
 
 export interface FloodConfig {
+  allowlist?: string[];
+
   identical?: FloodIdenticalConfig;
 
   similar?: FloodSimilarConfig;
@@ -11538,6 +11600,8 @@ export interface FloodIdenticalRuleParameters {
   threshold?: number;
 
   time_window?: string;
+
+  allowlist?: string[];
 }
 
 export interface FloodSimilarConfig {
@@ -11558,6 +11622,8 @@ export interface FloodSimilarRuleParameters {
   threshold?: number;
 
   time_window?: string;
+
+  allowlist?: string[];
 }
 
 export interface FollowBatchRequest {
@@ -12292,6 +12358,11 @@ export interface GetFeedsRateLimitsResponse {
   server_side?: Record<string, LimitInfoResponse>;
 
   /**
+   * Rate limits for Unity platform (endpoint name -> limit info)
+   */
+  unity?: Record<string, LimitInfoResponse>;
+
+  /**
    * Rate limits for Web platform (endpoint name -> limit info)
    */
   web?: Record<string, LimitInfoResponse>;
@@ -12724,6 +12795,11 @@ export interface GetRateLimitsResponse {
    * Map of endpoint rate limits for the server-side platform
    */
   server_side?: Record<string, LimitInfoResponse>;
+
+  /**
+   * Map of endpoint rate limits for the Unity platform
+   */
+  unity?: Record<string, LimitInfoResponse>;
 
   /**
    * Map of endpoint rate limits for the web platform
@@ -14273,6 +14349,8 @@ export interface MatchedContent {
    */
   severity?: string;
 
+  text?: string;
+
   /**
    * Image-classification entries (keyframe rule, Type=image) carry nested L1 → L2 classifications. Text entries (closed_caption rule, Type=text) carry flat label + severity. Resolved against the app's effective taxonomy on the image side.
    */
@@ -14905,6 +14983,8 @@ export interface MessageNewEvent {
 
 export interface MessageOptions {
   include_thread_participants?: boolean;
+
+  member_custom_include?: string[];
 }
 
 export interface MessagePaginationParams {
@@ -18467,6 +18547,11 @@ export interface QueryChannelsRequest {
   state?: boolean;
 
   user_id?: string;
+
+  /**
+   * Top-level keys of the message sender's channel-member custom data to include under member.custom (max 8 keys, 64 chars each)
+   */
+  member_custom_include?: string[];
 
   /**
    * List of sort parameters
@@ -22562,7 +22647,7 @@ export interface StoriesFeedUpdatedEvent {
 
 export interface SubmitActionRequest {
   /**
-   * Type of moderation action to perform. One of: mark_reviewed, delete_message, delete_activity, delete_comment, delete_reaction, ban, custom, unban, restore, delete_user, unblock, block, shadow_block, unmask, kick_user, end_call, escalate, de_escalate
+   * Type of moderation action to perform. One of: mark_reviewed, delete_message, delete_activity, delete_comment, delete_reaction, ban, custom, unban, restore, delete_user, delete_user_messages, unblock, block, shadow_block, unmask, kick_user, end_call, escalate, de_escalate
    */
 
   action_type:
@@ -22577,6 +22662,7 @@ export interface SubmitActionRequest {
     | 'unban'
     | 'restore'
     | 'delete_user'
+    | 'delete_user_messages'
     | 'unblock'
     | 'block'
     | 'shadow_block'
@@ -22617,6 +22703,8 @@ export interface SubmitActionRequest {
   delete_reaction?: DeleteReactionRequestPayload;
 
   delete_user?: DeleteUserRequestPayload;
+
+  delete_user_messages?: DeleteUserMessagesRequestPayload;
 
   escalate?: EscalatePayload;
 
@@ -24143,10 +24231,14 @@ export interface UpdateBlockListRequest {
 
   team?: string;
 
+  user_id?: string;
+
   /**
    * List of words to block
    */
   words?: string[];
+
+  user?: UserRequest;
 }
 
 export interface UpdateBlockListResponse {
@@ -25192,6 +25284,9 @@ export interface UpdatePollOptionRequest {
 
   user_id?: string;
 
+  /**
+   * Custom data for this object
+   */
   custom?: Record<string, any>;
 
   user?: UserRequest;
@@ -25267,6 +25362,9 @@ export interface UpdatePollRequest {
    */
   options?: PollOptionRequest[];
 
+  /**
+   * Custom data for this object
+   */
   custom?: Record<string, any>;
 
   user?: UserRequest;

--- a/src/gen/moderation/ModerationApi.ts
+++ b/src/gen/moderation/ModerationApi.ts
@@ -1235,6 +1235,7 @@ export class ModerationApi {
       delete_message: request?.delete_message,
       delete_reaction: request?.delete_reaction,
       delete_user: request?.delete_user,
+      delete_user_messages: request?.delete_user_messages,
       escalate: request?.escalate,
       flag: request?.flag,
       mark_reviewed: request?.mark_reviewed,


### PR DESCRIPTION
Regenerates the client from the `chat` serverside spec at **v233.25.1** (previously v233.9.1, #324).

## Chat: `member_custom_include`

New request parameter that projects selected top-level keys of the message sender's channel-member custom data under `member.custom` (max 8 keys, 64 chars each). Added to:

- `ChannelApi.getManyMessages`
- `ChatApi.getManyMessages`
- `ChatApi.getReplies`
- `ChatApi.queryChannels` (`QueryChannelsRequest`)
- `ChatApi.getOrCreateChannel` / `ChatApi.getOrCreateDistinctChannel` (`ChannelGetOrCreateRequest`)
- `MessageOptions`

Response side: `ChannelMemberPartialResponse.custom?: Record<string, any>` carries the projected fields.

## Video: encryption settings ⚠️ breaking

`EncryptionSettings` moves from a boolean toggle to a tri-state mode:

```diff
 interface EncryptionSettingsRequest {
-  enabled?: boolean;
+  mode?: 'available' | 'disabled' | 'auto-on';
 }

 interface EncryptionSettingsResponse {
-  enabled: boolean;
+  mode: 'available' | 'disabled' | 'auto-on';
 }
```

**Migration for consumers:** replace `encryption: { enabled: true }` with `encryption: { mode: 'auto-on' }` (or `'available'` to allow but not force E2EE), and `enabled: false` with `mode: 'disabled'`. Reads of `response.encryption.enabled` become `response.encryption.mode`.

Nothing inside this repo referenced these fields, so build, typecheck and tests are unaffected — but it is a source-breaking change for SDK users. Titled `feat:` to match prior spec-update PRs (#324 also removed public methods under a plain `feat:`); flagging here so it can be re-scoped to `feat!:` if you'd rather cut 0.8.0 than 0.7.64.

## Moderation

- New `delete_user_messages` action on `SubmitActionRequest`, with `DeleteUserMessagesRequestPayload`: `delete_messages` mode (`soft` | `pruning` | `hard`), optional `channel_cid` to scope to one channel, `delete_reactions`, `entity_id` / `entity_type`, `reason`.
- `FilterConfigResponse.ai_image_taxonomy` — available AI image moderation labels as an L1 → L2 map, reflecting the app's effective image taxonomy.
- `MatchedContent.text`.
- `allowlist?: string[]` on `FloodConfig`, `FloodIdenticalRuleParameters` and `FloodSimilarRuleParameters`.

## Blocklists: server-side user context

`user_id` / `user` on `CreateBlockListRequest` and `UpdateBlockListRequest`; `user_id` on `deleteBlockList`.

## Rate limits: Unity platform

`unity` request flag and `unity?: Record<string, LimitInfoResponse>` response field on `CommonApi.getRateLimits` and `FeedsApi.getFeedsRateLimits`.

## Not included: importer external storage

The spec still exposes `/api/v2/imports/v2/external-storage[/validate]`, so codegen re-added the four methods #324 removed as "decidedly not part of Stream's public API". They have been stripped again here, along with their models and decoder:

- `deleteImporterExternalStorage`, `getImporterExternalStorage`, `upsertImporterExternalStorage`, `validateImporterExternalStorage`
- `GetExternalStorage{AWSS3,GCS,}Response`, `UpsertExternalStorage{AWSS3Request,GCSRequest,Request,Response}`, `ValidateExternalStorageResponse`
- `decoders.GetExternalStorageResponse`

Worth noting this is now a recurring manual post-generation edit — every regeneration will reintroduce it until the endpoints are excluded from the spec or the generator.

## Verification

- `yarn build` — passes
- `tsc --noEmit` — clean (exit 0)
- `yarn lint` — 0 errors
- `yarn lint:gen` — no reformatting needed
- `yarn test` — 143 passed / 6 failed / 19 skipped

The 6 failures (4× `permissions and app settings API` role tests, `rate limit > should include rate limit in errors as well`, `webhooks > verify webhook - user.updated`) reproduce identically on unmodified `main`, so they are pre-existing and environmental rather than caused by this change.

### CI `test-node` is red for a pre-existing reason

All four `test-node` matrix jobs fail here on `channel.test.ts:77`:

```
FAIL __tests__/channel.test.ts > channel API > queryChannels
AssertionError: expected 1 to be greater than 1
```

This is **not** caused by this PR. The same assertion at the same line fails on unmodified `main` — see [run 30007936823](https://github.com/GetStream/stream-node/actions/runs/30007936823) for `chore(main): release 0.7.63`. The `test.yml` workflow has failed on 9 of the last 12 `main` runs, including the merges of both #324 and #325.

The test does an unfiltered `client.chat.queryChannels()` and asserts `channels.length > 1`, so it depends on ambient channel data in the shared test app rather than on anything it sets up itself. `test-bun` — which runs the same suite — passes, and CI's `permissions`/`rate-limit`/`webhook` tests pass here while failing locally, which is the signature of shared-app/env data dependence rather than a code defect.

Worth fixing separately (have the test create the channels it counts, or filter to its own fixtures); out of scope for a codegen update.
