### PR TITLE
fix: correct query param serialization for arrays, dates and null

### DIFF
--- a/__tests__/query-params.test.ts
+++ b/__tests__/query-params.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ApiClient } from '../src/ApiClient';
+
+const createApiClient = () =>
+  new ApiClient({
+    apiKey: 'test-api-key',
+    token: 'test-token',
+    baseUrl: 'https://example.com',
+    timeout: 3000,
+  });
+
+/**
+ * Sends a request with the given query params and returns the query string
+ * that was actually put on the wire.
+ */
+const queryStringFor = async (queryParams: Record<string, any>) => {
+  const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify({}), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+
+  await createApiClient().sendRequest('GET', '/test', undefined, queryParams);
+
+  const requestedUrl = fetchSpy.mock.calls[0][0] as string;
+  return new URL(requestedUrl).search.replace(/^\?/, '');
+};
+
+describe('query param serialization', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('serializes an array of objects as JSON', async () => {
+    const search = await queryStringFor({
+      sort: [{ field: 'created_at', direction: 1 }],
+    });
+
+    expect(search).toContain(
+      `sort=${encodeURIComponent('[{"field":"created_at","direction":1}]')}`,
+    );
+  });
+
+  it('keeps the param name for Date values', async () => {
+    const search = await queryStringFor({
+      start_time: new Date('2026-08-15T10:00:00.000Z'),
+    });
+
+    expect(search).toContain(
+      `start_time=${encodeURIComponent('2026-08-15T10:00:00.000Z')}`,
+    );
+  });
+
+  it('serializes an array of strings comma-separated', async () => {
+    const search = await queryStringFor({ ids: ['first', 'second'] });
+
+    expect(search).toContain(`ids=${encodeURIComponent('first,second')}`);
+  });
+
+  it('drops empty entries from an array of strings', async () => {
+    const search = await queryStringFor({
+      ids: ['first', null, undefined, 'second'],
+    });
+
+    expect(search).toContain(`ids=${encodeURIComponent('first,second')}`);
+  });
+
+  it('drops empty entries from an array of objects', async () => {
+    const search = await queryStringFor({
+      sort: [{ field: 'created_at', direction: 1 }, null],
+    });
+
+    expect(search).toContain(
+      `sort=${encodeURIComponent('[{"field":"created_at","direction":1}]')}`,
+    );
+  });
+
+  it('serializes a nested object as JSON', async () => {
+    const search = await queryStringFor({
+      payload: { sort: [{ field: 'created_at', direction: 1 }] },
+    });
+
+    expect(search).toContain(
+      `payload=${encodeURIComponent(
+        '{"sort":[{"field":"created_at","direction":1}]}',
+      )}`,
+    );
+  });
+
+  it('omits params with no value', async () => {
+    const search = await queryStringFor({ limit: undefined, id_gt: null });
+
+    expect(search).toBe('api_key=test-api-key');
+  });
+});

--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import { ApiConfig, RequestMetadata, StreamError } from './types';
 import { APIError } from './gen/models';
 import { getRateLimitFromResponseHeader } from './utils/rate-limit';
+import { isScalar, stringifyArrayParam } from './utils/query-params';
 
 export class ApiClient {
   private readonly dispatcher?: RequestInit['dispatcher'];
@@ -128,20 +129,17 @@ export class ApiClient {
     const newParams = [];
     for (const k in params) {
       const param = params[k];
+      if (param === null || param === undefined) continue;
       if (Array.isArray(param)) {
-        newParams.push(`${k}=${encodeURIComponent(param.join(','))}`);
+        newParams.push(
+          `${k}=${encodeURIComponent(stringifyArrayParam(param))}`,
+        );
       } else if (param instanceof Date) {
-        newParams.push(param.toISOString());
+        newParams.push(`${k}=${encodeURIComponent(param.toISOString())}`);
       } else if (typeof param === 'object') {
         newParams.push(`${k}=${encodeURIComponent(JSON.stringify(param))}`);
-      } else {
-        if (
-          typeof param === 'string' ||
-          typeof param === 'number' ||
-          typeof param === 'boolean'
-        ) {
-          newParams.push(`${k}=${encodeURIComponent(param)}`);
-        }
+      } else if (isScalar(param)) {
+        newParams.push(`${k}=${encodeURIComponent(param)}`);
       }
     }
 

--- a/src/utils/query-params.ts
+++ b/src/utils/query-params.ts
@@ -1,0 +1,21 @@
+export const isScalar = (value: any) => {
+  const type = typeof value;
+  return type === 'string' || type === 'number' || type === 'boolean';
+};
+
+/**
+ * Scalar arrays go on the wire comma-separated (`ids=a,b`), anything else has
+ * to be JSON or it stringifies to `[object Object]`. `null` and `undefined`
+ * entries are dropped so that a single empty value can't flip the format.
+ */
+export const stringifyArrayParam = (param: any[]) => {
+  const entries = [];
+  let allScalar = true;
+  for (const entry of param) {
+    if (entry == null) continue;
+    if (!isScalar(entry)) allScalar = false;
+    entries.push(entry);
+  }
+
+  return allScalar ? entries.join(',') : JSON.stringify(entries);
+};


### PR DESCRIPTION
`queryParamsStringify` silently corrupted GET query strings in three ways. All of them failed silently — the request returned `200` with wrong data rather than erroring, so callers got no signal that the parameter was never sent.

## The bugs

**1. Arrays of objects serialized to `[object Object]`.** The array branch used `param.join(',')`, which stringifies each element via `String()`. The object branch immediately below it already used `JSON.stringify`.

```js
{ sort: [{ field: 'created_at', direction: 1 }] }
// before → sort=%5Bobject%20Object%5D
// after  → sort=%5B%7B%22field%22%3A%22created_at%22...
```

**2. `Date` params lost their key.** The `instanceof Date` branch pushed `param.toISOString()` with no `` `${k}=` `` prefix, dropping the key and injecting a bare, unencoded value into the query string.

```js
{ limit: 10, start_time: new Date('2026-08-15T10:00:00Z') }
// before → limit=10&2026-08-15T10:00:00.000Z    (key gone, server never sees it)
// after  → limit=10&start_time=2026-08-15T10%3A00%3A00.000Z
```

**3. `null` serialized as the literal string `"null"`.** `typeof null === 'object'`, so it took the object branch and `JSON.stringify(null)` produced `id_gt=null` on the wire. `undefined` was already dropped correctly.

## Affected endpoints

Audited every `*Api.ts` under `src/gen` for GET query params typed as an array of non-scalars or as `Date`:

| Bug | Endpoint | Param |
|---|---|---|
| 1 | `ChatApi.getReplies` | `sort?: SortParamRequest[]` |
| 1 | `VideoApi.queryCallSessionParticipantStats` | `sort?: SortParamRequest[]` |
| 2 | `VideoApi.getCallParticipantSessionMetrics` | `since?: Date`, `until?: Date` |
| 2 | `VideoApi.getCallStatsMap` | `start_time?: Date`, `end_time?: Date` |

`getReplies` returned unsorted replies, so an ordering assertion failed with no indication that the sort was never sent. For the Video endpoints, any caller passing a time range silently got an unfiltered one.

Not affected: `queryChannels`, `queryThreads`, `queryReminders` and `getRetentionPolicyRuns` are POST, so their sorts travel in the JSON body. `queryUsers`, `queryMembers` and `searchRoles` are GET but nest `sort` inside a `payload` object, which already took the correct `JSON.stringify` branch.

## The fix

Array handling moves to `src/utils/query-params.ts`, which resolves the wire format in a single pass:

- Scalar arrays keep the comma-separated form (`ids=a,b`). Switching those to JSON unconditionally — as `stream-chat`'s `axiosParamsSerializer` does — would be a breaking wire-format change for every string-array param, so the format is chosen per array. If the backend accepts a JSON array everywhere, this could be simplified; that's an API-owner call.
- Anything non-scalar is JSON encoded.
- `null`/`undefined` entries *within* an array are dropped, so a single empty value can't flip a scalar array from `a,b` to a JSON array.

## Verification

Unit tests cover all four wire formats plus the empty-value cases. Beyond that, the encodings were checked against the live API rather than assumed:

- The server parses and validates the JSON `sort` array — `sort=notjson` and a bare (non-array) JSON object are both rejected with `not a valid JSON for field 'sort'`, and a bogus field name is rejected with `Sorting is only supported on 'created_at' field`.
- `getReplies` with `limit=2` returns the two oldest replies for `direction: 1` and the two newest for `direction: -1`, confirming the sort is honoured end-to-end. Note the sort selects the page; in-page order is always chronological.
- `getCallStatsMap` with ISO `start_time`/`end_time` fails on the missing call rather than on the time format, confirming the dates parse.

The full suite shows no new failures; the remaining failures are pre-existing on `main` (live-API integration tests and a webhook-signature test).
