### PR TITLE
fix: order "types" first in package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.es.mjs",
-      "require": "./dist/index.cjs.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs.js"
     }
   },
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
Export conditions are matched top-to-bottom, first match wins. With `"import"` and `"require"` listed before `"types"`, the types condition was unreachable — consumers resolving through `"exports"` (`moduleResolution: node16` / `bundler`) never picked up the declarations, and esbuild warned on every `vitest` run:

```
▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]
```

Reordering `"types"` to the top fixes it. The top-level `"types"` field is kept as the fallback for legacy `moduleResolution: node`.

## Verification

- `yarn vitest run` no longer emits the warning (0 occurrences).
- No behavior change to the emitted bundles — this only affects resolution order.