### PR TITLE
feat: update to open api version 235.20.1

### DIFF
--- a/src/gen/chat/ChannelApi.ts
+++ b/src/gen/chat/ChannelApi.ts
@@ -6,6 +6,7 @@ import {
   EventResponse,
   GetDraftResponse,
   GetManyMessagesResponse,
+  GetPinnedMessagesResponse,
   HideChannelRequest,
   HideChannelResponse,
   MarkReadRequest,
@@ -17,6 +18,7 @@ import {
   SendMessageResponse,
   ShowChannelRequest,
   ShowChannelResponse,
+  SortParamRequest,
   TruncateChannelRequest,
   TruncateChannelResponse,
   UpdateChannelPartialRequest,
@@ -64,6 +66,7 @@ export class ChannelApi {
     messages_id_gt?: string;
     messages_id_gte?: string;
     messages_id_around?: string;
+    user_id?: string;
   }): Promise<StreamResponse<ChannelStateResponse>> {
     if (!this.id) {
       throw new Error(
@@ -263,8 +266,8 @@ export class ChannelApi {
   }
 
   getManyMessages(request: {
-    ids: string[];
-    member_custom_include?: string[];
+    ids: Array<string>;
+    member_custom_include?: Array<string>;
   }): Promise<StreamResponse<GetManyMessagesResponse>> {
     if (!this.id) {
       throw new Error(
@@ -273,6 +276,36 @@ export class ChannelApi {
     }
 
     return this.chatApi.getManyMessages({
+      id: this.id,
+      type: this.type,
+      ...request,
+    });
+  }
+
+  getPinnedMessages(request?: {
+    limit?: number;
+    offset?: number;
+    id_gte?: string;
+    id_gt?: string;
+    id_lte?: string;
+    id_lt?: string;
+    pinned_at_after_or_equal?: Date;
+    pinned_at_after?: Date;
+    pinned_at_before_or_equal?: Date;
+    pinned_at_before?: Date;
+    id_around?: string;
+    pinned_at_around?: Date;
+    user_id?: string;
+    sort?: Array<SortParamRequest>;
+    member_custom_include?: Array<string>;
+  }): Promise<StreamResponse<GetPinnedMessagesResponse>> {
+    if (!this.id) {
+      throw new Error(
+        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
+      );
+    }
+
+    return this.chatApi.getPinnedMessages({
       id: this.id,
       type: this.type,
       ...request,

--- a/src/gen/chat/ChatApi.ts
+++ b/src/gen/chat/ChatApi.ts
@@ -14,6 +14,8 @@ import {
   CreateChannelTypeResponse,
   CreateCommandRequest,
   CreateCommandResponse,
+  CreatePredefinedFilterRequest,
+  CreatePredefinedFilterResponse,
   CreateReminderRequest,
   CreateSegmentRequest,
   CreateSegmentResponse,
@@ -37,6 +39,8 @@ import {
   GetDraftResponse,
   GetManyMessagesResponse,
   GetMessageResponse,
+  GetPinnedMessagesResponse,
+  GetPredefinedFilterResponse,
   GetReactionsResponse,
   GetRepliesResponse,
   GetRetentionPolicyResponse,
@@ -77,6 +81,7 @@ import {
   QueryMessageFlagsResponse,
   QueryMessageHistoryRequest,
   QueryMessageHistoryResponse,
+  QueryPredefinedFiltersResponse,
   QueryReactionsRequest,
   QueryReactionsResponse,
   QueryRemindersRequest,
@@ -131,6 +136,8 @@ import {
   UpdateMessagePartialResponse,
   UpdateMessageRequest,
   UpdateMessageResponse,
+  UpdatePredefinedFilterRequest,
+  UpdatePredefinedFilterResponse,
   UpdateReminderRequest,
   UpdateReminderResponse,
   UpdateSegmentRequest,
@@ -179,7 +186,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.CreateCampaignResponse?.(response.body);
+    decoders['CreateCampaignResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -207,7 +214,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.QueryCampaignsResponse?.(response.body);
+    decoders['QueryCampaignsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -223,7 +230,7 @@ export class ChatApi {
       StreamResponse<DeleteCampaignResponse>
     >('DELETE', '/api/v2/chat/campaigns/{id}', pathParams, undefined);
 
-    decoders.DeleteCampaignResponse?.(response.body);
+    decoders['DeleteCampaignResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -247,7 +254,7 @@ export class ChatApi {
       StreamResponse<GetCampaignResponse>
     >('GET', '/api/v2/chat/campaigns/{id}', pathParams, queryParams);
 
-    decoders.GetCampaignResponse?.(response.body);
+    decoders['GetCampaignResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -286,7 +293,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.CampaignResponse?.(response.body);
+    decoders['CampaignResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -313,7 +320,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.StartCampaignResponse?.(response.body);
+    decoders['StartCampaignResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -337,7 +344,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.CampaignResponse?.(response.body);
+    decoders['CampaignResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -372,7 +379,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.QueryChannelsResponse?.(response.body);
+    decoders['QueryChannelsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -398,7 +405,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.ChannelBatchUpdateResponse?.(response.body);
+    decoders['ChannelBatchUpdateResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -422,7 +429,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.DeleteChannelsResponse?.(response.body);
+    decoders['DeleteChannelsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -448,7 +455,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.MarkDeliveredResponse?.(response.body);
+    decoders['MarkDeliveredResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -474,7 +481,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.GroupedQueryChannelsResponse?.(response.body);
+    decoders['GroupedQueryChannelsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -499,7 +506,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.MarkReadResponse?.(response.body);
+    decoders['MarkReadResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -532,7 +539,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.ChannelStateResponse?.(response.body);
+    decoders['ChannelStateResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -554,7 +561,7 @@ export class ChatApi {
       StreamResponse<DeleteChannelResponse>
     >('DELETE', '/api/v2/chat/channels/{type}/{id}', pathParams, queryParams);
 
-    decoders.DeleteChannelResponse?.(response.body);
+    decoders['DeleteChannelResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -571,6 +578,7 @@ export class ChatApi {
     messages_id_gt?: string;
     messages_id_gte?: string;
     messages_id_around?: string;
+    user_id?: string;
   }): Promise<StreamResponse<ChannelStateResponse>> {
     const queryParams = {
       state: request?.state,
@@ -582,6 +590,7 @@ export class ChatApi {
       messages_id_gt: request?.messages_id_gt,
       messages_id_gte: request?.messages_id_gte,
       messages_id_around: request?.messages_id_around,
+      user_id: request?.user_id,
     };
     const pathParams = {
       type: request?.type,
@@ -592,7 +601,7 @@ export class ChatApi {
       StreamResponse<ChannelStateResponse>
     >('GET', '/api/v2/chat/channels/{type}/{id}', pathParams, queryParams);
 
-    decoders.ChannelStateResponse?.(response.body);
+    decoders['ChannelStateResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -622,7 +631,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.UpdateChannelPartialResponse?.(response.body);
+    decoders['UpdateChannelPartialResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -666,7 +675,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.UpdateChannelResponse?.(response.body);
+    decoders['UpdateChannelResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -693,7 +702,7 @@ export class ChatApi {
       queryParams,
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -722,7 +731,7 @@ export class ChatApi {
       queryParams,
     );
 
-    decoders.GetDraftResponse?.(response.body);
+    decoders['GetDraftResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -749,7 +758,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.EventResponse?.(response.body);
+    decoders['EventResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -774,7 +783,7 @@ export class ChatApi {
       queryParams,
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -802,7 +811,7 @@ export class ChatApi {
       'multipart/form-data',
     );
 
-    decoders.UploadChannelFileResponse?.(response.body);
+    decoders['UploadChannelFileResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -831,7 +840,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.HideChannelResponse?.(response.body);
+    decoders['HideChannelResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -856,7 +865,7 @@ export class ChatApi {
       queryParams,
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -885,7 +894,7 @@ export class ChatApi {
       'multipart/form-data',
     );
 
-    decoders.UploadChannelResponse?.(response.body);
+    decoders['UploadChannelResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -920,7 +929,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.UpdateMemberPartialResponse?.(response.body);
+    decoders['UpdateMemberPartialResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -955,7 +964,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.SendMessageResponse?.(response.body);
+    decoders['SendMessageResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -963,8 +972,8 @@ export class ChatApi {
   async getManyMessages(request: {
     type: string;
     id: string;
-    ids: string[];
-    member_custom_include?: string[];
+    ids: Array<string>;
+    member_custom_include?: Array<string>;
   }): Promise<StreamResponse<GetManyMessagesResponse>> {
     const queryParams = {
       ids: request?.ids,
@@ -984,7 +993,62 @@ export class ChatApi {
       queryParams,
     );
 
-    decoders.GetManyMessagesResponse?.(response.body);
+    decoders['GetManyMessagesResponse']?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getPinnedMessages(request: {
+    type: string;
+    id: string;
+    limit?: number;
+    offset?: number;
+    id_gte?: string;
+    id_gt?: string;
+    id_lte?: string;
+    id_lt?: string;
+    pinned_at_after_or_equal?: Date;
+    pinned_at_after?: Date;
+    pinned_at_before_or_equal?: Date;
+    pinned_at_before?: Date;
+    id_around?: string;
+    pinned_at_around?: Date;
+    user_id?: string;
+    sort?: Array<SortParamRequest>;
+    member_custom_include?: Array<string>;
+  }): Promise<StreamResponse<GetPinnedMessagesResponse>> {
+    const queryParams = {
+      limit: request?.limit,
+      offset: request?.offset,
+      id_gte: request?.id_gte,
+      id_gt: request?.id_gt,
+      id_lte: request?.id_lte,
+      id_lt: request?.id_lt,
+      pinned_at_after_or_equal: request?.pinned_at_after_or_equal,
+      pinned_at_after: request?.pinned_at_after,
+      pinned_at_before_or_equal: request?.pinned_at_before_or_equal,
+      pinned_at_before: request?.pinned_at_before,
+      id_around: request?.id_around,
+      pinned_at_around: request?.pinned_at_around,
+      user_id: request?.user_id,
+      sort: request?.sort,
+      member_custom_include: request?.member_custom_include,
+    };
+    const pathParams = {
+      type: request?.type,
+      id: request?.id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetPinnedMessagesResponse>
+    >(
+      'GET',
+      '/api/v2/chat/channels/{type}/{id}/pinned_messages',
+      pathParams,
+      queryParams,
+    );
+
+    decoders['GetPinnedMessagesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1018,7 +1082,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.ChannelStateResponse?.(response.body);
+    decoders['ChannelStateResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1048,7 +1112,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.MarkReadResponse?.(response.body);
+    decoders['MarkReadResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1076,7 +1140,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.ShowChannelResponse?.(response.body);
+    decoders['ShowChannelResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1109,7 +1173,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.TruncateChannelResponse?.(response.body);
+    decoders['TruncateChannelResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1138,7 +1202,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1148,7 +1212,7 @@ export class ChatApi {
       StreamResponse<ListChannelTypesResponse>
     >('GET', '/api/v2/chat/channeltypes', undefined, undefined);
 
-    decoders.ListChannelTypesResponse?.(response.body);
+    decoders['ListChannelTypesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1204,7 +1268,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.CreateChannelTypeResponse?.(response.body);
+    decoders['CreateChannelTypeResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1223,7 +1287,7 @@ export class ChatApi {
       undefined,
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1239,7 +1303,7 @@ export class ChatApi {
       StreamResponse<GetChannelTypeResponse>
     >('GET', '/api/v2/chat/channeltypes/{name}', pathParams, undefined);
 
-    decoders.GetChannelTypeResponse?.(response.body);
+    decoders['GetChannelTypeResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1300,7 +1364,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.UpdateChannelTypeResponse?.(response.body);
+    decoders['UpdateChannelTypeResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1310,7 +1374,7 @@ export class ChatApi {
       StreamResponse<ListCommandsResponse>
     >('GET', '/api/v2/chat/commands', undefined, undefined);
 
-    decoders.ListCommandsResponse?.(response.body);
+    decoders['ListCommandsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1336,7 +1400,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.CreateCommandResponse?.(response.body);
+    decoders['CreateCommandResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1352,7 +1416,7 @@ export class ChatApi {
       StreamResponse<DeleteCommandResponse>
     >('DELETE', '/api/v2/chat/commands/{name}', pathParams, undefined);
 
-    decoders.DeleteCommandResponse?.(response.body);
+    decoders['DeleteCommandResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1368,7 +1432,7 @@ export class ChatApi {
       StreamResponse<GetCommandResponse>
     >('GET', '/api/v2/chat/commands/{name}', pathParams, undefined);
 
-    decoders.GetCommandResponse?.(response.body);
+    decoders['GetCommandResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1396,7 +1460,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.UpdateCommandResponse?.(response.body);
+    decoders['UpdateCommandResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1425,7 +1489,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.QueryDraftsResponse?.(response.body);
+    decoders['QueryDraftsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1455,7 +1519,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.ExportChannelsResponse?.(response.body);
+    decoders['ExportChannelsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1471,7 +1535,7 @@ export class ChatApi {
       StreamResponse<MembersResponse>
     >('GET', '/api/v2/chat/members', undefined, queryParams);
 
-    decoders.MembersResponse?.(response.body);
+    decoders['MembersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1498,7 +1562,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.QueryMessageHistoryResponse?.(response.body);
+    decoders['QueryMessageHistoryResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1522,7 +1586,7 @@ export class ChatApi {
       StreamResponse<DeleteMessageResponse>
     >('DELETE', '/api/v2/chat/messages/{id}', pathParams, queryParams);
 
-    decoders.DeleteMessageResponse?.(response.body);
+    decoders['DeleteMessageResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1542,7 +1606,7 @@ export class ChatApi {
       StreamResponse<GetMessageResponse>
     >('GET', '/api/v2/chat/messages/{id}', pathParams, queryParams);
 
-    decoders.GetMessageResponse?.(response.body);
+    decoders['GetMessageResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1570,7 +1634,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.UpdateMessageResponse?.(response.body);
+    decoders['UpdateMessageResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1601,7 +1665,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.UpdateMessagePartialResponse?.(response.body);
+    decoders['UpdateMessagePartialResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1629,7 +1693,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.MessageActionResponse?.(response.body);
+    decoders['MessageActionResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1653,7 +1717,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.MessageActionResponse?.(response.body);
+    decoders['MessageActionResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1684,7 +1748,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.UpdateMessagePartialResponse?.(response.body);
+    decoders['UpdateMessagePartialResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1712,7 +1776,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.SendReactionResponse?.(response.body);
+    decoders['SendReactionResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1739,7 +1803,7 @@ export class ChatApi {
       queryParams,
     );
 
-    decoders.DeleteReactionResponse?.(response.body);
+    decoders['DeleteReactionResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1761,7 +1825,7 @@ export class ChatApi {
       StreamResponse<GetReactionsResponse>
     >('GET', '/api/v2/chat/messages/{id}/reactions', pathParams, queryParams);
 
-    decoders.GetReactionsResponse?.(response.body);
+    decoders['GetReactionsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1793,7 +1857,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.QueryReactionsResponse?.(response.body);
+    decoders['QueryReactionsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1819,7 +1883,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.MessageActionResponse?.(response.body);
+    decoders['MessageActionResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1845,7 +1909,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.UndeleteMessageResponse?.(response.body);
+    decoders['UndeleteMessageResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1874,7 +1938,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.PollVoteResponse?.(response.body);
+    decoders['PollVoteResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1903,7 +1967,7 @@ export class ChatApi {
       queryParams,
     );
 
-    decoders.PollVoteResponse?.(response.body);
+    decoders['PollVoteResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1928,7 +1992,7 @@ export class ChatApi {
       queryParams,
     );
 
-    decoders.DeleteReminderResponse?.(response.body);
+    decoders['DeleteReminderResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1956,7 +2020,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.UpdateReminderResponse?.(response.body);
+    decoders['UpdateReminderResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1984,7 +2048,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.ReminderResponseData?.(response.body);
+    decoders['ReminderResponseData']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1997,8 +2061,8 @@ export class ChatApi {
     id_lte?: string;
     id_lt?: string;
     id_around?: string;
-    sort?: SortParamRequest[];
-    member_custom_include?: string[];
+    sort?: Array<SortParamRequest>;
+    member_custom_include?: Array<string>;
   }): Promise<StreamResponse<GetRepliesResponse>> {
     const queryParams = {
       limit: request?.limit,
@@ -2023,7 +2087,7 @@ export class ChatApi {
       queryParams,
     );
 
-    decoders.GetRepliesResponse?.(response.body);
+    decoders['GetRepliesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2039,7 +2103,7 @@ export class ChatApi {
       StreamResponse<QueryMessageFlagsResponse>
     >('GET', '/api/v2/chat/moderation/flags/message', undefined, queryParams);
 
-    decoders.QueryMessageFlagsResponse?.(response.body);
+    decoders['QueryMessageFlagsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2065,7 +2129,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.MuteChannelResponse?.(response.body);
+    decoders['MuteChannelResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2091,7 +2155,116 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.UnmuteResponse?.(response.body);
+    decoders['UnmuteResponse']?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getPredefinedFilters(request?: {
+    include_stats?: boolean;
+    sort?: Array<SortParamRequest>;
+  }): Promise<StreamResponse<QueryPredefinedFiltersResponse>> {
+    const queryParams = {
+      include_stats: request?.include_stats,
+      sort: request?.sort,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<QueryPredefinedFiltersResponse>
+    >('GET', '/api/v2/chat/predefined_filters', undefined, queryParams);
+
+    decoders['QueryPredefinedFiltersResponse']?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async createPredefinedFilter(
+    request: CreatePredefinedFilterRequest,
+  ): Promise<StreamResponse<CreatePredefinedFilterResponse>> {
+    const body = {
+      name: request?.name,
+      operation: request?.operation,
+      filter: request?.filter,
+      description: request?.description,
+      sort: request?.sort,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<CreatePredefinedFilterResponse>
+    >(
+      'POST',
+      '/api/v2/chat/predefined_filters',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders['CreatePredefinedFilterResponse']?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deletePredefinedFilter(request: {
+    name: string;
+  }): Promise<StreamResponse<Response>> {
+    const pathParams = {
+      name: request?.name,
+    };
+
+    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
+      'DELETE',
+      '/api/v2/chat/predefined_filters/{name}',
+      pathParams,
+      undefined,
+    );
+
+    decoders['Response']?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getPredefinedFilter(request: {
+    name: string;
+  }): Promise<StreamResponse<GetPredefinedFilterResponse>> {
+    const pathParams = {
+      name: request?.name,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetPredefinedFilterResponse>
+    >('GET', '/api/v2/chat/predefined_filters/{name}', pathParams, undefined);
+
+    decoders['GetPredefinedFilterResponse']?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updatePredefinedFilter(
+    request: UpdatePredefinedFilterRequest & { name: string },
+  ): Promise<StreamResponse<UpdatePredefinedFilterResponse>> {
+    const pathParams = {
+      name: request?.name,
+    };
+    const body = {
+      operation: request?.operation,
+      filter: request?.filter,
+      description: request?.description,
+      sort: request?.sort,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<UpdatePredefinedFilterResponse>
+    >(
+      'PUT',
+      '/api/v2/chat/predefined_filters/{name}',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders['UpdatePredefinedFilterResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2107,7 +2280,7 @@ export class ChatApi {
       StreamResponse<QueryBannedUsersResponse>
     >('GET', '/api/v2/chat/query_banned_users', undefined, queryParams);
 
-    decoders.QueryBannedUsersResponse?.(response.body);
+    decoders['QueryBannedUsersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2123,7 +2296,7 @@ export class ChatApi {
       StreamResponse<QueryFutureChannelBansResponse>
     >('GET', '/api/v2/chat/query_future_channel_bans', undefined, queryParams);
 
-    decoders.QueryFutureChannelBansResponse?.(response.body);
+    decoders['QueryFutureChannelBansResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2152,7 +2325,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.QueryRemindersResponse?.(response.body);
+    decoders['QueryRemindersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2164,7 +2337,7 @@ export class ChatApi {
       StreamResponse<GetRetentionPolicyResponse>
     >('GET', '/api/v2/chat/retention_policy', undefined, undefined);
 
-    decoders.GetRetentionPolicyResponse?.(response.body);
+    decoders['GetRetentionPolicyResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2188,7 +2361,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.SetRetentionPolicyResponse?.(response.body);
+    decoders['SetRetentionPolicyResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2211,7 +2384,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.DeleteRetentionPolicyResponse?.(response.body);
+    decoders['DeleteRetentionPolicyResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2238,7 +2411,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.GetRetentionPolicyRunsResponse?.(response.body);
+    decoders['GetRetentionPolicyRunsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2254,7 +2427,7 @@ export class ChatApi {
       StreamResponse<SearchResponse>
     >('GET', '/api/v2/chat/search', undefined, queryParams);
 
-    decoders.SearchResponse?.(response.body);
+    decoders['SearchResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2283,7 +2456,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.CreateSegmentResponse?.(response.body);
+    decoders['CreateSegmentResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2310,7 +2483,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.QuerySegmentsResponse?.(response.body);
+    decoders['QuerySegmentsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2329,7 +2502,7 @@ export class ChatApi {
       undefined,
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2345,7 +2518,7 @@ export class ChatApi {
       StreamResponse<GetSegmentResponse>
     >('GET', '/api/v2/chat/segments/{id}', pathParams, undefined);
 
-    decoders.GetSegmentResponse?.(response.body);
+    decoders['GetSegmentResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2373,7 +2546,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.UpdateSegmentResponse?.(response.body);
+    decoders['UpdateSegmentResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2397,7 +2570,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2421,7 +2594,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2442,7 +2615,7 @@ export class ChatApi {
       undefined,
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2472,7 +2645,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.QuerySegmentTargetsResponse?.(response.body);
+    decoders['QuerySegmentTargetsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2486,6 +2659,7 @@ export class ChatApi {
       month: request?.month,
       next: request?.next,
       start_date: request?.start_date,
+      team: request?.team,
     };
 
     const response = await this.apiClient.sendRequest<
@@ -2499,7 +2673,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.QueryTeamUsageStatsResponse?.(response.body);
+    decoders['QueryTeamUsageStatsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2531,7 +2705,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.QueryThreadsResponse?.(response.body);
+    decoders['QueryThreadsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2555,7 +2729,7 @@ export class ChatApi {
       StreamResponse<GetThreadResponse>
     >('GET', '/api/v2/chat/threads/{message_id}', pathParams, queryParams);
 
-    decoders.GetThreadResponse?.(response.body);
+    decoders['GetThreadResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2584,7 +2758,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.UpdateThreadPartialResponse?.(response.body);
+    decoders['UpdateThreadPartialResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2600,7 +2774,7 @@ export class ChatApi {
       StreamResponse<WrappedUnreadCountsResponse>
     >('GET', '/api/v2/chat/unread', undefined, queryParams);
 
-    decoders.WrappedUnreadCountsResponse?.(response.body);
+    decoders['WrappedUnreadCountsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2623,7 +2797,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.UnreadCountsBatchResponse?.(response.body);
+    decoders['UnreadCountsBatchResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2647,7 +2821,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }

--- a/src/gen/common/CommonApi.ts
+++ b/src/gen/common/CommonApi.ts
@@ -69,6 +69,7 @@ import {
   ListPushProvidersResponse,
   ListRolesResponse,
   ListUserGroupsResponse,
+  PermissionRequest,
   PollOptionResponse,
   PollResponse,
   PollVotesResponse,
@@ -125,7 +126,7 @@ export class CommonApi {
       StreamResponse<GetApplicationResponse>
     >('GET', '/api/v2/app', undefined, undefined);
 
-    decoders.GetApplicationResponse?.(response.body);
+    decoders['GetApplicationResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -208,7 +209,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -228,7 +229,7 @@ export class CommonApi {
       StreamResponse<ListBlockListResponse>
     >('GET', '/api/v2/blocklists', undefined, queryParams);
 
-    decoders.ListBlockListResponse?.(response.body);
+    decoders['ListBlockListResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -260,7 +261,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.CreateBlockListResponse?.(response.body);
+    decoders['CreateBlockListResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -287,7 +288,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.ImportBlockListResponse?.(response.body);
+    decoders['ImportBlockListResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -312,7 +313,7 @@ export class CommonApi {
       queryParams,
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -332,7 +333,7 @@ export class CommonApi {
       StreamResponse<GetBlockListResponse>
     >('GET', '/api/v2/blocklists/{name}', pathParams, queryParams);
 
-    decoders.GetBlockListResponse?.(response.body);
+    decoders['GetBlockListResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -365,7 +366,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.UpdateBlockListResponse?.(response.body);
+    decoders['UpdateBlockListResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -397,7 +398,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.CheckPushResponse?.(response.body);
+    decoders['CheckPushResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -422,7 +423,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.CheckSNSResponse?.(response.body);
+    decoders['CheckSNSResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -447,7 +448,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.CheckSQSResponse?.(response.body);
+    decoders['CheckSQSResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -468,7 +469,7 @@ export class CommonApi {
       queryParams,
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -484,7 +485,7 @@ export class CommonApi {
       StreamResponse<ListDevicesResponse>
     >('GET', '/api/v2/devices', undefined, queryParams);
 
-    decoders.ListDevicesResponse?.(response.body);
+    decoders['ListDevicesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -511,7 +512,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -534,7 +535,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.ExportUsersResponse?.(response.body);
+    decoders['ExportUsersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -546,7 +547,7 @@ export class CommonApi {
       StreamResponse<ListExternalStorageResponse>
     >('GET', '/api/v2/external_storage', undefined, undefined);
 
-    decoders.ListExternalStorageResponse?.(response.body);
+    decoders['ListExternalStorageResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -575,7 +576,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.CreateExternalStorageResponse?.(response.body);
+    decoders['CreateExternalStorageResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -591,7 +592,7 @@ export class CommonApi {
       StreamResponse<DeleteExternalStorageResponse>
     >('DELETE', '/api/v2/external_storage/{name}', pathParams, undefined);
 
-    decoders.DeleteExternalStorageResponse?.(response.body);
+    decoders['DeleteExternalStorageResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -622,7 +623,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.UpdateExternalStorageResponse?.(response.body);
+    decoders['UpdateExternalStorageResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -638,7 +639,7 @@ export class CommonApi {
       StreamResponse<CheckExternalStorageResponse>
     >('GET', '/api/v2/external_storage/{name}/check', pathParams, undefined);
 
-    decoders.CheckExternalStorageResponse?.(response.body);
+    decoders['CheckExternalStorageResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -654,7 +655,7 @@ export class CommonApi {
       StreamResponse<CreateGuestResponse>
     >('POST', '/api/v2/guest', undefined, undefined, body, 'application/json');
 
-    decoders.CreateGuestResponse?.(response.body);
+    decoders['CreateGuestResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -677,7 +678,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.CreateImportURLResponse?.(response.body);
+    decoders['CreateImportURLResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -687,7 +688,7 @@ export class CommonApi {
       StreamResponse<ListImportsResponse>
     >('GET', '/api/v2/imports', undefined, undefined);
 
-    decoders.ListImportsResponse?.(response.body);
+    decoders['ListImportsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -712,7 +713,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.CreateImportResponse?.(response.body);
+    decoders['CreateImportResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -728,7 +729,7 @@ export class CommonApi {
       StreamResponse<ListImportV2TasksResponse>
     >('GET', '/api/v2/imports/v2', undefined, queryParams);
 
-    decoders.ListImportV2TasksResponse?.(response.body);
+    decoders['ListImportV2TasksResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -754,7 +755,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.CreateImportV2TaskResponse?.(response.body);
+    decoders['CreateImportV2TaskResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -766,7 +767,7 @@ export class CommonApi {
       StreamResponse<DeleteExternalStorageResponse>
     >('DELETE', '/api/v2/imports/v2/external-storage', undefined, undefined);
 
-    decoders.DeleteExternalStorageResponse?.(response.body);
+    decoders['DeleteExternalStorageResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -778,7 +779,7 @@ export class CommonApi {
       StreamResponse<GetExternalStorageResponse>
     >('GET', '/api/v2/imports/v2/external-storage', undefined, undefined);
 
-    decoders.GetExternalStorageResponse?.(response.body);
+    decoders['GetExternalStorageResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -803,7 +804,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.UpsertExternalStorageResponse?.(response.body);
+    decoders['UpsertExternalStorageResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -820,7 +821,7 @@ export class CommonApi {
       undefined,
     );
 
-    decoders.ValidateExternalStorageResponse?.(response.body);
+    decoders['ValidateExternalStorageResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -836,7 +837,7 @@ export class CommonApi {
       StreamResponse<DeleteImportV2TaskResponse>
     >('DELETE', '/api/v2/imports/v2/{id}', pathParams, undefined);
 
-    decoders.DeleteImportV2TaskResponse?.(response.body);
+    decoders['DeleteImportV2TaskResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -852,7 +853,7 @@ export class CommonApi {
       StreamResponse<GetImportV2TaskResponse>
     >('GET', '/api/v2/imports/v2/{id}', pathParams, undefined);
 
-    decoders.GetImportV2TaskResponse?.(response.body);
+    decoders['GetImportV2TaskResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -868,7 +869,7 @@ export class CommonApi {
       StreamResponse<CancelImportV2TaskResponse>
     >('POST', '/api/v2/imports/v2/{id}/cancel', pathParams, undefined);
 
-    decoders.CancelImportV2TaskResponse?.(response.body);
+    decoders['CancelImportV2TaskResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -884,7 +885,7 @@ export class CommonApi {
       StreamResponse<GetImportResponse>
     >('GET', '/api/v2/imports/{id}', pathParams, undefined);
 
-    decoders.GetImportResponse?.(response.body);
+    decoders['GetImportResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -900,7 +901,7 @@ export class CommonApi {
       StreamResponse<GetOGResponse>
     >('GET', '/api/v2/og', undefined, queryParams);
 
-    decoders.GetOGResponse?.(response.body);
+    decoders['GetOGResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -910,7 +911,52 @@ export class CommonApi {
       StreamResponse<ListPermissionsResponse>
     >('GET', '/api/v2/permissions', undefined, undefined);
 
-    decoders.ListPermissionsResponse?.(response.body);
+    decoders['ListPermissionsResponse']?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async createPermission(
+    request: PermissionRequest,
+  ): Promise<StreamResponse<Response>> {
+    const body = {
+      action: request?.action,
+      name: request?.name,
+      description: request?.description,
+      owner: request?.owner,
+      same_team: request?.same_team,
+      condition: request?.condition,
+    };
+
+    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
+      'POST',
+      '/api/v2/permissions',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders['Response']?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async deletePermission(request: {
+    id: string;
+  }): Promise<StreamResponse<Response>> {
+    const pathParams = {
+      id: request?.id,
+    };
+
+    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
+      'DELETE',
+      '/api/v2/permissions/{id}',
+      pathParams,
+      undefined,
+    );
+
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -926,7 +972,36 @@ export class CommonApi {
       StreamResponse<GetCustomPermissionResponse>
     >('GET', '/api/v2/permissions/{id}', pathParams, undefined);
 
-    decoders.GetCustomPermissionResponse?.(response.body);
+    decoders['GetCustomPermissionResponse']?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async updatePermission(
+    request: PermissionRequest & { id: string },
+  ): Promise<StreamResponse<Response>> {
+    const pathParams = {
+      id: request?.id,
+    };
+    const body = {
+      action: request?.action,
+      name: request?.name,
+      description: request?.description,
+      owner: request?.owner,
+      same_team: request?.same_team,
+      condition: request?.condition,
+    };
+
+    const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
+      'PUT',
+      '/api/v2/permissions/{id}',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+    );
+
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -954,7 +1029,7 @@ export class CommonApi {
       StreamResponse<PollResponse>
     >('POST', '/api/v2/polls', undefined, undefined, body, 'application/json');
 
-    decoders.PollResponse?.(response.body);
+    decoders['PollResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -982,7 +1057,7 @@ export class CommonApi {
       StreamResponse<PollResponse>
     >('PUT', '/api/v2/polls', undefined, undefined, body, 'application/json');
 
-    decoders.PollResponse?.(response.body);
+    decoders['PollResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1012,7 +1087,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.QueryPollsResponse?.(response.body);
+    decoders['QueryPollsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1035,7 +1110,7 @@ export class CommonApi {
       queryParams,
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1055,7 +1130,7 @@ export class CommonApi {
       StreamResponse<PollResponse>
     >('GET', '/api/v2/polls/{poll_id}', pathParams, queryParams);
 
-    decoders.PollResponse?.(response.body);
+    decoders['PollResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1084,7 +1159,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.PollResponse?.(response.body);
+    decoders['PollResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1113,7 +1188,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.PollOptionResponse?.(response.body);
+    decoders['PollOptionResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1143,7 +1218,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.PollOptionResponse?.(response.body);
+    decoders['PollOptionResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1168,7 +1243,7 @@ export class CommonApi {
       queryParams,
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1191,7 +1266,7 @@ export class CommonApi {
       undefined,
     );
 
-    decoders.PollOptionResponse?.(response.body);
+    decoders['PollOptionResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1224,7 +1299,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.PollVotesResponse?.(response.body);
+    decoders['PollVotesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1247,7 +1322,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.UpsertPushPreferencesResponse?.(response.body);
+    decoders['UpsertPushPreferencesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1259,7 +1334,7 @@ export class CommonApi {
       StreamResponse<ListPushProvidersResponse>
     >('GET', '/api/v2/push_providers', undefined, undefined);
 
-    decoders.ListPushProvidersResponse?.(response.body);
+    decoders['ListPushProvidersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1282,7 +1357,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.UpsertPushProviderResponse?.(response.body);
+    decoders['UpsertPushProviderResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1303,7 +1378,7 @@ export class CommonApi {
       undefined,
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1321,7 +1396,7 @@ export class CommonApi {
       StreamResponse<GetPushTemplatesResponse>
     >('GET', '/api/v2/push_templates', undefined, queryParams);
 
-    decoders.GetPushTemplatesResponse?.(response.body);
+    decoders['GetPushTemplatesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1348,7 +1423,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.UpsertPushTemplateResponse?.(response.body);
+    decoders['UpsertPushTemplateResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1374,7 +1449,7 @@ export class CommonApi {
       StreamResponse<GetRateLimitsResponse>
     >('GET', '/api/v2/rate_limits', undefined, queryParams);
 
-    decoders.GetRateLimitsResponse?.(response.body);
+    decoders['GetRateLimitsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1384,7 +1459,7 @@ export class CommonApi {
       StreamResponse<ListRolesResponse>
     >('GET', '/api/v2/roles', undefined, undefined);
 
-    decoders.ListRolesResponse?.(response.body);
+    decoders['ListRolesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1400,7 +1475,7 @@ export class CommonApi {
       StreamResponse<CreateRoleResponse>
     >('POST', '/api/v2/roles', undefined, undefined, body, 'application/json');
 
-    decoders.CreateRoleResponse?.(response.body);
+    decoders['CreateRoleResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1424,7 +1499,7 @@ export class CommonApi {
       StreamResponse<SearchRolesResponse>
     >('GET', '/api/v2/roles/search', undefined, queryParams);
 
-    decoders.SearchRolesResponse?.(response.body);
+    decoders['SearchRolesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1443,7 +1518,7 @@ export class CommonApi {
       undefined,
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1459,7 +1534,7 @@ export class CommonApi {
       StreamResponse<GetTaskResponse>
     >('GET', '/api/v2/tasks/{id}', pathParams, undefined);
 
-    decoders.GetTaskResponse?.(response.body);
+    decoders['GetTaskResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1478,7 +1553,7 @@ export class CommonApi {
       queryParams,
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1502,7 +1577,7 @@ export class CommonApi {
       'multipart/form-data',
     );
 
-    decoders.FileUploadResponse?.(response.body);
+    decoders['FileUploadResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1521,7 +1596,7 @@ export class CommonApi {
       queryParams,
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1546,7 +1621,7 @@ export class CommonApi {
       'multipart/form-data',
     );
 
-    decoders.ImageUploadResponse?.(response.body);
+    decoders['ImageUploadResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1568,7 +1643,7 @@ export class CommonApi {
       StreamResponse<ListUserGroupsResponse>
     >('GET', '/api/v2/usergroups', undefined, queryParams);
 
-    decoders.ListUserGroupsResponse?.(response.body);
+    decoders['ListUserGroupsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1595,7 +1670,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.CreateUserGroupResponse?.(response.body);
+    decoders['CreateUserGroupResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1619,7 +1694,7 @@ export class CommonApi {
       StreamResponse<SearchUserGroupsResponse>
     >('GET', '/api/v2/usergroups/search', undefined, queryParams);
 
-    decoders.SearchUserGroupsResponse?.(response.body);
+    decoders['SearchUserGroupsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1642,7 +1717,7 @@ export class CommonApi {
       queryParams,
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1662,7 +1737,7 @@ export class CommonApi {
       StreamResponse<GetUserGroupResponse>
     >('GET', '/api/v2/usergroups/{id}', pathParams, queryParams);
 
-    decoders.GetUserGroupResponse?.(response.body);
+    decoders['GetUserGroupResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1690,7 +1765,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.UpdateUserGroupResponse?.(response.body);
+    decoders['UpdateUserGroupResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1718,7 +1793,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.AddUserGroupMembersResponse?.(response.body);
+    decoders['AddUserGroupMembersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1745,7 +1820,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.RemoveUserGroupMembersResponse?.(response.body);
+    decoders['RemoveUserGroupMembersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1761,7 +1836,7 @@ export class CommonApi {
       StreamResponse<QueryUsersResponse>
     >('GET', '/api/v2/users', undefined, queryParams);
 
-    decoders.QueryUsersResponse?.(response.body);
+    decoders['QueryUsersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1777,7 +1852,7 @@ export class CommonApi {
       StreamResponse<UpdateUsersResponse>
     >('PATCH', '/api/v2/users', undefined, undefined, body, 'application/json');
 
-    decoders.UpdateUsersResponse?.(response.body);
+    decoders['UpdateUsersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1793,7 +1868,7 @@ export class CommonApi {
       StreamResponse<UpdateUsersResponse>
     >('POST', '/api/v2/users', undefined, undefined, body, 'application/json');
 
-    decoders.UpdateUsersResponse?.(response.body);
+    decoders['UpdateUsersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1809,7 +1884,7 @@ export class CommonApi {
       StreamResponse<GetBlockedUsersResponse>
     >('GET', '/api/v2/users/block', undefined, queryParams);
 
-    decoders.GetBlockedUsersResponse?.(response.body);
+    decoders['GetBlockedUsersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1834,7 +1909,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.BlockUsersResponse?.(response.body);
+    decoders['BlockUsersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1860,7 +1935,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.DeactivateUsersResponse?.(response.body);
+    decoders['DeactivateUsersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1890,7 +1965,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.DeleteUsersResponse?.(response.body);
+    decoders['DeleteUsersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1906,7 +1981,7 @@ export class CommonApi {
       StreamResponse<SharedLocationsResponse>
     >('GET', '/api/v2/users/live_locations', undefined, queryParams);
 
-    decoders.SharedLocationsResponse?.(response.body);
+    decoders['SharedLocationsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1935,7 +2010,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.SharedLocationResponse?.(response.body);
+    decoders['SharedLocationResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1961,7 +2036,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.ReactivateUsersResponse?.(response.body);
+    decoders['ReactivateUsersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1982,7 +2057,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2007,7 +2082,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.UnblockUsersResponse?.(response.body);
+    decoders['UnblockUsersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2034,7 +2109,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.DeactivateUserResponse?.(response.body);
+    decoders['DeactivateUserResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2050,7 +2125,7 @@ export class CommonApi {
       StreamResponse<ExportUserResponse>
     >('GET', '/api/v2/users/{user_id}/export', pathParams, undefined);
 
-    decoders.ExportUserResponse?.(response.body);
+    decoders['ExportUserResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2078,7 +2153,7 @@ export class CommonApi {
       'application/json',
     );
 
-    decoders.ReactivateUserResponse?.(response.body);
+    decoders['ReactivateUserResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }

--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -223,7 +223,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.AddActivityResponse?.(response.body);
+    decoders['AddActivityResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -249,7 +249,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.UpsertActivitiesResponse?.(response.body);
+    decoders['UpsertActivitiesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -273,7 +273,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.UpdateActivitiesPartialBatchResponse?.(response.body);
+    decoders['UpdateActivitiesPartialBatchResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -300,7 +300,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.DeleteActivitiesResponse?.(response.body);
+    decoders['DeleteActivitiesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -325,7 +325,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.TrackActivityMetricsResponse?.(response.body);
+    decoders['TrackActivityMetricsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -365,7 +365,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.QueryActivitiesResponse?.(response.body);
+    decoders['QueryActivitiesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -395,7 +395,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.BatchQueryActivityReactionsResponse?.(response.body);
+    decoders['BatchQueryActivityReactionsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -422,7 +422,7 @@ export class FeedsApi {
       queryParams,
     );
 
-    decoders.DeleteBookmarkResponse?.(response.body);
+    decoders['DeleteBookmarkResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -453,7 +453,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.UpdateBookmarkResponse?.(response.body);
+    decoders['UpdateBookmarkResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -483,7 +483,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.AddBookmarkResponse?.(response.body);
+    decoders['AddBookmarkResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -513,7 +513,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.ActivityFeedbackResponse?.(response.body);
+    decoders['ActivityFeedbackResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -542,7 +542,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.PollVoteResponse?.(response.body);
+    decoders['PollVoteResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -571,7 +571,7 @@ export class FeedsApi {
       queryParams,
     );
 
-    decoders.PollVoteResponse?.(response.body);
+    decoders['PollVoteResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -606,7 +606,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.AddReactionResponse?.(response.body);
+    decoders['AddReactionResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -636,7 +636,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.QueryActivityReactionsResponse?.(response.body);
+    decoders['QueryActivityReactionsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -665,7 +665,7 @@ export class FeedsApi {
       queryParams,
     );
 
-    decoders.DeleteActivityReactionResponse?.(response.body);
+    decoders['DeleteActivityReactionResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -694,7 +694,7 @@ export class FeedsApi {
       queryParams,
     );
 
-    decoders.QueryActivitySharesResponse?.(response.body);
+    decoders['QueryActivitySharesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -716,7 +716,7 @@ export class FeedsApi {
       StreamResponse<DeleteActivityResponse>
     >('DELETE', '/api/v2/feeds/activities/{id}', pathParams, queryParams);
 
-    decoders.DeleteActivityResponse?.(response.body);
+    decoders['DeleteActivityResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -744,7 +744,7 @@ export class FeedsApi {
       StreamResponse<GetActivityResponse>
     >('GET', '/api/v2/feeds/activities/{id}', pathParams, queryParams);
 
-    decoders.GetActivityResponse?.(response.body);
+    decoders['GetActivityResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -778,7 +778,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.UpdateActivityPartialResponse?.(response.body);
+    decoders['UpdateActivityPartialResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -826,7 +826,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.UpdateActivityResponse?.(response.body);
+    decoders['UpdateActivityResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -859,7 +859,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.RestoreActivityResponse?.(response.body);
+    decoders['RestoreActivityResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -885,7 +885,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.TranslateActivityResponse?.(response.body);
+    decoders['TranslateActivityResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -912,7 +912,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.QueryBookmarkFoldersResponse?.(response.body);
+    decoders['QueryBookmarkFoldersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -933,7 +933,7 @@ export class FeedsApi {
       undefined,
     );
 
-    decoders.DeleteBookmarkFolderResponse?.(response.body);
+    decoders['DeleteBookmarkFolderResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -962,7 +962,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.UpdateBookmarkFolderResponse?.(response.body);
+    decoders['UpdateBookmarkFolderResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -999,13 +999,13 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.QueryBookmarksResponse?.(response.body);
+    decoders['QueryBookmarksResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
 
   async deleteCollections(request: {
-    collection_refs: string[];
+    collection_refs: Array<string>;
   }): Promise<StreamResponse<DeleteCollectionsResponse>> {
     const queryParams = {
       collection_refs: request?.collection_refs,
@@ -1015,14 +1015,14 @@ export class FeedsApi {
       StreamResponse<DeleteCollectionsResponse>
     >('DELETE', '/api/v2/feeds/collections', undefined, queryParams);
 
-    decoders.DeleteCollectionsResponse?.(response.body);
+    decoders['DeleteCollectionsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
 
   async readCollections(request?: {
     user_id?: string;
-    collection_refs?: string[];
+    collection_refs?: Array<string>;
   }): Promise<StreamResponse<ReadCollectionsResponse>> {
     const queryParams = {
       user_id: request?.user_id,
@@ -1033,7 +1033,7 @@ export class FeedsApi {
       StreamResponse<ReadCollectionsResponse>
     >('GET', '/api/v2/feeds/collections', undefined, queryParams);
 
-    decoders.ReadCollectionsResponse?.(response.body);
+    decoders['ReadCollectionsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1058,7 +1058,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.UpdateCollectionsResponse?.(response.body);
+    decoders['UpdateCollectionsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1083,7 +1083,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.CreateCollectionsResponse?.(response.body);
+    decoders['CreateCollectionsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1106,7 +1106,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.UpsertCollectionsResponse?.(response.body);
+    decoders['UpsertCollectionsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1135,7 +1135,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.QueryCollectionsResponse?.(response.body);
+    decoders['QueryCollectionsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1173,7 +1173,7 @@ export class FeedsApi {
       StreamResponse<GetCommentsResponse>
     >('GET', '/api/v2/feeds/comments', undefined, queryParams);
 
-    decoders.GetCommentsResponse?.(response.body);
+    decoders['GetCommentsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1210,7 +1210,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.AddCommentResponse?.(response.body);
+    decoders['AddCommentResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1233,7 +1233,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.AddCommentsBatchResponse?.(response.body);
+    decoders['AddCommentsBatchResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1270,7 +1270,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.QueryCommentsResponse?.(response.body);
+    decoders['QueryCommentsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1300,7 +1300,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.BatchQueryCommentReactionsResponse?.(response.body);
+    decoders['BatchQueryCommentReactionsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1327,7 +1327,7 @@ export class FeedsApi {
       queryParams,
     );
 
-    decoders.DeleteCommentBookmarkResponse?.(response.body);
+    decoders['DeleteCommentBookmarkResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1358,7 +1358,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.UpdateCommentBookmarkResponse?.(response.body);
+    decoders['UpdateCommentBookmarkResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1388,7 +1388,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.AddCommentBookmarkResponse?.(response.body);
+    decoders['AddCommentBookmarkResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1410,7 +1410,7 @@ export class FeedsApi {
       StreamResponse<DeleteCommentResponse>
     >('DELETE', '/api/v2/feeds/comments/{id}', pathParams, queryParams);
 
-    decoders.DeleteCommentResponse?.(response.body);
+    decoders['DeleteCommentResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1434,7 +1434,7 @@ export class FeedsApi {
       StreamResponse<GetCommentResponse>
     >('GET', '/api/v2/feeds/comments/{id}', pathParams, queryParams);
 
-    decoders.GetCommentResponse?.(response.body);
+    decoders['GetCommentResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1470,7 +1470,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.UpdateCommentResponse?.(response.body);
+    decoders['UpdateCommentResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1504,7 +1504,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.UpdateCommentPartialResponse?.(response.body);
+    decoders['UpdateCommentPartialResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1538,7 +1538,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.AddCommentReactionResponse?.(response.body);
+    decoders['AddCommentReactionResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1568,7 +1568,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.QueryCommentReactionsResponse?.(response.body);
+    decoders['QueryCommentReactionsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1597,7 +1597,7 @@ export class FeedsApi {
       queryParams,
     );
 
-    decoders.DeleteCommentReactionResponse?.(response.body);
+    decoders['DeleteCommentReactionResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1635,7 +1635,7 @@ export class FeedsApi {
       StreamResponse<GetCommentRepliesResponse>
     >('GET', '/api/v2/feeds/comments/{id}/replies', pathParams, queryParams);
 
-    decoders.GetCommentRepliesResponse?.(response.body);
+    decoders['GetCommentRepliesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1662,7 +1662,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.RestoreCommentResponse?.(response.body);
+    decoders['RestoreCommentResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1688,7 +1688,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.TranslateCommentResponse?.(response.body);
+    decoders['TranslateCommentResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1704,7 +1704,7 @@ export class FeedsApi {
       StreamResponse<ListFeedGroupsResponse>
     >('GET', '/api/v2/feeds/feed_groups', undefined, queryParams);
 
-    decoders.ListFeedGroupsResponse?.(response.body);
+    decoders['ListFeedGroupsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1737,7 +1737,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.CreateFeedGroupResponse?.(response.body);
+    decoders['CreateFeedGroupResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1766,7 +1766,7 @@ export class FeedsApi {
       queryParams,
     );
 
-    decoders.DeleteFeedResponse?.(response.body);
+    decoders['DeleteFeedResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1819,7 +1819,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.GetOrCreateFeedResponse?.(response.body);
+    decoders['GetOrCreateFeedResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1853,7 +1853,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.UpdateFeedResponse?.(response.body);
+    decoders['UpdateFeedResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1884,7 +1884,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1915,7 +1915,7 @@ export class FeedsApi {
       queryParams,
     );
 
-    decoders.UnpinActivityResponse?.(response.body);
+    decoders['UnpinActivityResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1949,7 +1949,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.PinActivityResponse?.(response.body);
+    decoders['PinActivityResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1980,7 +1980,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.ChangeFeedVisibilityResponse?.(response.body);
+    decoders['ChangeFeedVisibilityResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2014,7 +2014,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.UpdateFeedMembersResponse?.(response.body);
+    decoders['UpdateFeedMembersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2045,7 +2045,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.AcceptFeedMemberInviteResponse?.(response.body);
+    decoders['AcceptFeedMemberInviteResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2079,7 +2079,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.QueryFeedMembersResponse?.(response.body);
+    decoders['QueryFeedMembersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2110,7 +2110,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.RejectFeedMemberInviteResponse?.(response.body);
+    decoders['RejectFeedMemberInviteResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2151,7 +2151,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.QueryPinnedActivitiesResponse?.(response.body);
+    decoders['QueryPinnedActivitiesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2178,7 +2178,7 @@ export class FeedsApi {
       queryParams,
     );
 
-    decoders.GetFollowSuggestionsResponse?.(response.body);
+    decoders['GetFollowSuggestionsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2199,7 +2199,7 @@ export class FeedsApi {
       undefined,
     );
 
-    decoders.RestoreFeedGroupResponse?.(response.body);
+    decoders['RestoreFeedGroupResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2219,7 +2219,7 @@ export class FeedsApi {
       StreamResponse<DeleteFeedGroupResponse>
     >('DELETE', '/api/v2/feeds/feed_groups/{id}', pathParams, queryParams);
 
-    decoders.DeleteFeedGroupResponse?.(response.body);
+    decoders['DeleteFeedGroupResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2239,7 +2239,7 @@ export class FeedsApi {
       StreamResponse<GetFeedGroupResponse>
     >('GET', '/api/v2/feeds/feed_groups/{id}', pathParams, queryParams);
 
-    decoders.GetFeedGroupResponse?.(response.body);
+    decoders['GetFeedGroupResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2274,7 +2274,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.GetOrCreateFeedGroupResponse?.(response.body);
+    decoders['GetOrCreateFeedGroupResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2309,7 +2309,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.UpdateFeedGroupResponse?.(response.body);
+    decoders['UpdateFeedGroupResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2319,7 +2319,7 @@ export class FeedsApi {
       StreamResponse<ListFeedViewsResponse>
     >('GET', '/api/v2/feeds/feed_views', undefined, undefined);
 
-    decoders.ListFeedViewsResponse?.(response.body);
+    decoders['ListFeedViewsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2345,7 +2345,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.CreateFeedViewResponse?.(response.body);
+    decoders['CreateFeedViewResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2361,7 +2361,7 @@ export class FeedsApi {
       StreamResponse<DeleteFeedViewResponse>
     >('DELETE', '/api/v2/feeds/feed_views/{id}', pathParams, undefined);
 
-    decoders.DeleteFeedViewResponse?.(response.body);
+    decoders['DeleteFeedViewResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2377,7 +2377,7 @@ export class FeedsApi {
       StreamResponse<GetFeedViewResponse>
     >('GET', '/api/v2/feeds/feed_views/{id}', pathParams, undefined);
 
-    decoders.GetFeedViewResponse?.(response.body);
+    decoders['GetFeedViewResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2405,7 +2405,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.GetOrCreateFeedViewResponse?.(response.body);
+    decoders['GetOrCreateFeedViewResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2433,7 +2433,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.UpdateFeedViewResponse?.(response.body);
+    decoders['UpdateFeedViewResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2445,7 +2445,7 @@ export class FeedsApi {
       StreamResponse<ListFeedVisibilitiesResponse>
     >('GET', '/api/v2/feeds/feed_visibilities', undefined, undefined);
 
-    decoders.ListFeedVisibilitiesResponse?.(response.body);
+    decoders['ListFeedVisibilitiesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2461,7 +2461,7 @@ export class FeedsApi {
       StreamResponse<GetFeedVisibilityResponse>
     >('GET', '/api/v2/feeds/feed_visibilities/{name}', pathParams, undefined);
 
-    decoders.GetFeedVisibilityResponse?.(response.body);
+    decoders['GetFeedVisibilityResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2487,7 +2487,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.UpdateFeedVisibilityResponse?.(response.body);
+    decoders['UpdateFeedVisibilityResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2511,7 +2511,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.CreateFeedsBatchResponse?.(response.body);
+    decoders['CreateFeedsBatchResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2536,7 +2536,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.DeleteFeedsBatchResponse?.(response.body);
+    decoders['DeleteFeedsBatchResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2562,7 +2562,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.OwnBatchResponse?.(response.body);
+    decoders['OwnBatchResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2591,7 +2591,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.QueryFeedsResponse?.(response.body);
+    decoders['QueryFeedsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2617,7 +2617,7 @@ export class FeedsApi {
       StreamResponse<GetFeedsRateLimitsResponse>
     >('GET', '/api/v2/feeds/feeds/rate_limits', undefined, queryParams);
 
-    decoders.GetFeedsRateLimitsResponse?.(response.body);
+    decoders['GetFeedsRateLimitsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2651,7 +2651,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.UpdateFollowResponse?.(response.body);
+    decoders['UpdateFollowResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2684,7 +2684,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.SingleFollowResponse?.(response.body);
+    decoders['SingleFollowResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2709,7 +2709,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.AcceptFollowResponse?.(response.body);
+    decoders['AcceptFollowResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2734,7 +2734,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.FollowBatchResponse?.(response.body);
+    decoders['FollowBatchResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2759,7 +2759,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.FollowBatchResponse?.(response.body);
+    decoders['FollowBatchResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2786,7 +2786,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.QueryFollowsResponse?.(response.body);
+    decoders['QueryFollowsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2810,7 +2810,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.RejectFollowResponse?.(response.body);
+    decoders['RejectFollowResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2843,7 +2843,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.GetOrCreateFollowResponse?.(response.body);
+    decoders['GetOrCreateFollowResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2874,7 +2874,7 @@ export class FeedsApi {
       queryParams,
     );
 
-    decoders.UnfollowResponse?.(response.body);
+    decoders['UnfollowResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2902,7 +2902,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.CreateMembershipLevelResponse?.(response.body);
+    decoders['CreateMembershipLevelResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2929,7 +2929,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.QueryMembershipLevelsResponse?.(response.body);
+    decoders['QueryMembershipLevelsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2948,7 +2948,7 @@ export class FeedsApi {
       undefined,
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -2978,7 +2978,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.UpdateMembershipLevelResponse?.(response.body);
+    decoders['UpdateMembershipLevelResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -3005,7 +3005,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.QueryRevisionHistoryResponse?.(response.body);
+    decoders['QueryRevisionHistoryResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -3029,7 +3029,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.QueryFeedsUsageStatsResponse?.(response.body);
+    decoders['QueryFeedsUsageStatsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -3054,7 +3054,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.UnfollowBatchResponse?.(response.body);
+    decoders['UnfollowBatchResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -3079,7 +3079,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.UnfollowBatchResponse?.(response.body);
+    decoders['UnfollowBatchResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -3106,7 +3106,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.GetOrCreateUnfollowResponse?.(response.body);
+    decoders['GetOrCreateUnfollowResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -3132,7 +3132,7 @@ export class FeedsApi {
       'application/json',
     );
 
-    decoders.DeleteFeedUserDataResponse?.(response.body);
+    decoders['DeleteFeedUserDataResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -3148,7 +3148,7 @@ export class FeedsApi {
       StreamResponse<ExportFeedUserDataResponse>
     >('POST', '/api/v2/feeds/users/{user_id}/export', pathParams, undefined);
 
-    decoders.ExportFeedUserDataResponse?.(response.body);
+    decoders['ExportFeedUserDataResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -3173,7 +3173,7 @@ export class FeedsApi {
       queryParams,
     );
 
-    decoders.GetUserInterestsResponse?.(response.body);
+    decoders['GetUserInterestsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }

--- a/src/gen/model-decoders/decoders.ts
+++ b/src/gen/model-decoders/decoders.ts
@@ -34,21 +34,23 @@ const decode = (typeMappings: TypeMapping, input?: Record<string, any>) => {
   return input;
 };
 
-decoders.AcceptFeedMemberInviteResponse = (input?: Record<string, any>) => {
+decoders['AcceptFeedMemberInviteResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     member: { type: 'FeedMemberResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.AcceptFollowResponse = (input?: Record<string, any>) => {
+decoders['AcceptFollowResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     follow: { type: 'FollowResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ActionLogResponse = (input?: Record<string, any>) => {
+decoders['ActionLogResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -61,7 +63,7 @@ decoders.ActionLogResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ActivityAddedEvent = (input?: Record<string, any>) => {
+decoders['ActivityAddedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -74,7 +76,7 @@ decoders.ActivityAddedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ActivityDeletedEvent = (input?: Record<string, any>) => {
+decoders['ActivityDeletedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -87,7 +89,7 @@ decoders.ActivityDeletedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ActivityFeedbackEvent = (input?: Record<string, any>) => {
+decoders['ActivityFeedbackEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -98,7 +100,7 @@ decoders.ActivityFeedbackEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ActivityMarkEvent = (input?: Record<string, any>) => {
+decoders['ActivityMarkEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -109,7 +111,7 @@ decoders.ActivityMarkEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ActivityPinResponse = (input?: Record<string, any>) => {
+decoders['ActivityPinResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -122,7 +124,7 @@ decoders.ActivityPinResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ActivityPinnedEvent = (input?: Record<string, any>) => {
+decoders['ActivityPinnedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -135,7 +137,7 @@ decoders.ActivityPinnedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ActivityReactionAddedEvent = (input?: Record<string, any>) => {
+decoders['ActivityReactionAddedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -150,7 +152,7 @@ decoders.ActivityReactionAddedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ActivityReactionDeletedEvent = (input?: Record<string, any>) => {
+decoders['ActivityReactionDeletedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -165,7 +167,7 @@ decoders.ActivityReactionDeletedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ActivityReactionUpdatedEvent = (input?: Record<string, any>) => {
+decoders['ActivityReactionUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -180,7 +182,7 @@ decoders.ActivityReactionUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ActivityRemovedFromFeedEvent = (input?: Record<string, any>) => {
+decoders['ActivityRemovedFromFeedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -193,7 +195,7 @@ decoders.ActivityRemovedFromFeedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ActivityResponse = (input?: Record<string, any>) => {
+decoders['ActivityResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -234,7 +236,7 @@ decoders.ActivityResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ActivityRestoredEvent = (input?: Record<string, any>) => {
+decoders['ActivityRestoredEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -247,14 +249,16 @@ decoders.ActivityRestoredEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ActivitySelectorConfigResponse = (input?: Record<string, any>) => {
+decoders['ActivitySelectorConfigResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     cutoff_time: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ActivityUnpinnedEvent = (input?: Record<string, any>) => {
+decoders['ActivityUnpinnedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -267,7 +271,7 @@ decoders.ActivityUnpinnedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ActivityUpdatedEvent = (input?: Record<string, any>) => {
+decoders['ActivityUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -280,28 +284,28 @@ decoders.ActivityUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.AddActivityResponse = (input?: Record<string, any>) => {
+decoders['AddActivityResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     activity: { type: 'ActivityResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.AddBookmarkResponse = (input?: Record<string, any>) => {
+decoders['AddBookmarkResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     bookmark: { type: 'BookmarkResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.AddCommentBookmarkResponse = (input?: Record<string, any>) => {
+decoders['AddCommentBookmarkResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     bookmark: { type: 'BookmarkResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.AddCommentReactionResponse = (input?: Record<string, any>) => {
+decoders['AddCommentReactionResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     comment: { type: 'CommentResponse', isSingle: true },
 
@@ -312,21 +316,21 @@ decoders.AddCommentReactionResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.AddCommentResponse = (input?: Record<string, any>) => {
+decoders['AddCommentResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     comment: { type: 'CommentResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.AddCommentsBatchResponse = (input?: Record<string, any>) => {
+decoders['AddCommentsBatchResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     comments: { type: 'CommentResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.AddReactionResponse = (input?: Record<string, any>) => {
+decoders['AddReactionResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     activity: { type: 'ActivityResponse', isSingle: true },
 
@@ -337,14 +341,14 @@ decoders.AddReactionResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.AddUserGroupMembersResponse = (input?: Record<string, any>) => {
+decoders['AddUserGroupMembersResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     user_group: { type: 'UserGroupResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.AggregatedActivityResponse = (input?: Record<string, any>) => {
+decoders['AggregatedActivityResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -355,7 +359,7 @@ decoders.AggregatedActivityResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.AppResponseFields = (input?: Record<string, any>) => {
+decoders['AppResponseFields'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     event_hooks: { type: 'EventHook', isSingle: false },
 
@@ -370,7 +374,7 @@ decoders.AppResponseFields = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.AppealAcceptedEvent = (input?: Record<string, any>) => {
+decoders['AppealAcceptedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -381,7 +385,7 @@ decoders.AppealAcceptedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.AppealCreatedEvent = (input?: Record<string, any>) => {
+decoders['AppealCreatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -392,7 +396,7 @@ decoders.AppealCreatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.AppealItemResponse = (input?: Record<string, any>) => {
+decoders['AppealItemResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -411,7 +415,7 @@ decoders.AppealItemResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.AppealRejectedEvent = (input?: Record<string, any>) => {
+decoders['AppealRejectedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -422,7 +426,9 @@ decoders.AppealRejectedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.AsyncBulkImageModerationEvent = (input?: Record<string, any>) => {
+decoders['AsyncBulkImageModerationEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -435,7 +441,7 @@ decoders.AsyncBulkImageModerationEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.AsyncExportChannelsEvent = (input?: Record<string, any>) => {
+decoders['AsyncExportChannelsEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -448,7 +454,7 @@ decoders.AsyncExportChannelsEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.AsyncExportErrorEvent = (input?: Record<string, any>) => {
+decoders['AsyncExportErrorEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -461,7 +467,9 @@ decoders.AsyncExportErrorEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.AsyncExportModerationLogsEvent = (input?: Record<string, any>) => {
+decoders['AsyncExportModerationLogsEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -474,7 +482,7 @@ decoders.AsyncExportModerationLogsEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.AsyncExportReviewQueueEvent = (input?: Record<string, any>) => {
+decoders['AsyncExportReviewQueueEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -487,7 +495,7 @@ decoders.AsyncExportReviewQueueEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.AsyncExportUsersEvent = (input?: Record<string, any>) => {
+decoders['AsyncExportUsersEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -500,14 +508,14 @@ decoders.AsyncExportUsersEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.AutomodDetailsResponse = (input?: Record<string, any>) => {
+decoders['AutomodDetailsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     result: { type: 'MessageModerationResult', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.BanInfoResponse = (input?: Record<string, any>) => {
+decoders['BanInfoResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -522,7 +530,7 @@ decoders.BanInfoResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.BanResponse = (input?: Record<string, any>) => {
+decoders['BanResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -537,23 +545,25 @@ decoders.BanResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.BatchQueryActivityReactionsResponse = (
-  input?: Record<string, any>,
-) => {
+decoders['BatchQueryActivityReactionsResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     reactions: { type: 'FeedsReactionResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.BatchQueryCommentReactionsResponse = (input?: Record<string, any>) => {
+decoders['BatchQueryCommentReactionsResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     reactions: { type: 'FeedsReactionResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.BlockListResponse = (input?: Record<string, any>) => {
+decoders['BlockListResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -562,14 +572,14 @@ decoders.BlockListResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.BlockUsersResponse = (input?: Record<string, any>) => {
+decoders['BlockUsersResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.BlockedUserEvent = (input?: Record<string, any>) => {
+decoders['BlockedUserEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -580,7 +590,7 @@ decoders.BlockedUserEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.BlockedUserResponse = (input?: Record<string, any>) => {
+decoders['BlockedUserResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -591,7 +601,7 @@ decoders.BlockedUserResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.BookmarkAddedEvent = (input?: Record<string, any>) => {
+decoders['BookmarkAddedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -604,7 +614,7 @@ decoders.BookmarkAddedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.BookmarkDeletedEvent = (input?: Record<string, any>) => {
+decoders['BookmarkDeletedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -617,7 +627,7 @@ decoders.BookmarkDeletedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.BookmarkFolderDeletedEvent = (input?: Record<string, any>) => {
+decoders['BookmarkFolderDeletedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -630,7 +640,7 @@ decoders.BookmarkFolderDeletedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.BookmarkFolderResponse = (input?: Record<string, any>) => {
+decoders['BookmarkFolderResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -641,7 +651,7 @@ decoders.BookmarkFolderResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.BookmarkFolderUpdatedEvent = (input?: Record<string, any>) => {
+decoders['BookmarkFolderUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -654,7 +664,7 @@ decoders.BookmarkFolderUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.BookmarkResponse = (input?: Record<string, any>) => {
+decoders['BookmarkResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -671,7 +681,7 @@ decoders.BookmarkResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.BookmarkUpdatedEvent = (input?: Record<string, any>) => {
+decoders['BookmarkUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -684,21 +694,21 @@ decoders.BookmarkUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.BulkActionAppealsResponse = (input?: Record<string, any>) => {
+decoders['BulkActionAppealsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     results: { type: 'BulkAppealResult', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.BulkAppealResult = (input?: Record<string, any>) => {
+decoders['BulkAppealResult'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     appeal_item: { type: 'AppealItemResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CallAcceptedEvent = (input?: Record<string, any>) => {
+decoders['CallAcceptedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -709,28 +719,34 @@ decoders.CallAcceptedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallClosedCaptionsFailedEvent = (input?: Record<string, any>) => {
+decoders['CallClosedCaptionsFailedEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CallClosedCaptionsStartedEvent = (input?: Record<string, any>) => {
+decoders['CallClosedCaptionsStartedEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CallClosedCaptionsStoppedEvent = (input?: Record<string, any>) => {
+decoders['CallClosedCaptionsStoppedEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CallCreatedEvent = (input?: Record<string, any>) => {
+decoders['CallCreatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -741,7 +757,7 @@ decoders.CallCreatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallDTMFEvent = (input?: Record<string, any>) => {
+decoders['CallDTMFEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -752,7 +768,7 @@ decoders.CallDTMFEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallDeletedEvent = (input?: Record<string, any>) => {
+decoders['CallDeletedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -761,7 +777,7 @@ decoders.CallDeletedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallEndedEvent = (input?: Record<string, any>) => {
+decoders['CallEndedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -774,7 +790,9 @@ decoders.CallEndedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallFrameRecordingFailedEvent = (input?: Record<string, any>) => {
+decoders['CallFrameRecordingFailedEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -783,7 +801,9 @@ decoders.CallFrameRecordingFailedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallFrameRecordingFrameReadyEvent = (input?: Record<string, any>) => {
+decoders['CallFrameRecordingFrameReadyEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     captured_at: { type: 'DatetimeType', isSingle: true },
 
@@ -794,7 +814,9 @@ decoders.CallFrameRecordingFrameReadyEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallFrameRecordingStartedEvent = (input?: Record<string, any>) => {
+decoders['CallFrameRecordingStartedEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -803,7 +825,9 @@ decoders.CallFrameRecordingStartedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallFrameRecordingStoppedEvent = (input?: Record<string, any>) => {
+decoders['CallFrameRecordingStoppedEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -812,30 +836,18 @@ decoders.CallFrameRecordingStoppedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallHLSBroadcastingFailedEvent = (input?: Record<string, any>) => {
+decoders['CallHLSBroadcastingFailedEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CallHLSBroadcastingStartedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    call: { type: 'CallResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CallHLSBroadcastingStoppedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CallLiveStartedEvent = (input?: Record<string, any>) => {
+decoders['CallHLSBroadcastingStartedEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -844,7 +856,25 @@ decoders.CallLiveStartedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallMemberAddedEvent = (input?: Record<string, any>) => {
+decoders['CallHLSBroadcastingStoppedEvent'] = (input?: {
+  [key: string]: any;
+}) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['CallLiveStartedEvent'] = (input?: { [key: string]: any }) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    call: { type: 'CallResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['CallMemberAddedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -855,7 +885,7 @@ decoders.CallMemberAddedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallMemberRemovedEvent = (input?: Record<string, any>) => {
+decoders['CallMemberRemovedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -864,7 +894,7 @@ decoders.CallMemberRemovedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallMemberUpdatedEvent = (input?: Record<string, any>) => {
+decoders['CallMemberUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -875,7 +905,9 @@ decoders.CallMemberUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallMemberUpdatedPermissionEvent = (input?: Record<string, any>) => {
+decoders['CallMemberUpdatedPermissionEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -886,34 +918,7 @@ decoders.CallMemberUpdatedPermissionEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallMissedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    members: { type: 'MemberResponse', isSingle: false },
-
-    call: { type: 'CallResponse', isSingle: true },
-
-    user: { type: 'UserResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CallModerationBlurEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CallModerationWarningEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CallNotificationEvent = (input?: Record<string, any>) => {
+decoders['CallMissedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -926,7 +931,34 @@ decoders.CallNotificationEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallParticipantResponse = (input?: Record<string, any>) => {
+decoders['CallModerationBlurEvent'] = (input?: { [key: string]: any }) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['CallModerationWarningEvent'] = (input?: { [key: string]: any }) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['CallNotificationEvent'] = (input?: { [key: string]: any }) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    members: { type: 'MemberResponse', isSingle: false },
+
+    call: { type: 'CallResponse', isSingle: true },
+
+    user: { type: 'UserResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['CallParticipantResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     joined_at: { type: 'DatetimeType', isSingle: true },
 
@@ -935,21 +967,21 @@ decoders.CallParticipantResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallParticipantTimeline = (input?: Record<string, any>) => {
+decoders['CallParticipantTimeline'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     timestamp: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CallReactionEvent = (input?: Record<string, any>) => {
+decoders['CallReactionEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CallRecording = (input?: Record<string, any>) => {
+decoders['CallRecording'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     end_time: { type: 'DatetimeType', isSingle: true },
 
@@ -958,14 +990,14 @@ decoders.CallRecording = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallRecordingFailedEvent = (input?: Record<string, any>) => {
+decoders['CallRecordingFailedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CallRecordingReadyEvent = (input?: Record<string, any>) => {
+decoders['CallRecordingReadyEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -974,21 +1006,21 @@ decoders.CallRecordingReadyEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallRecordingStartedEvent = (input?: Record<string, any>) => {
+decoders['CallRecordingStartedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CallRecordingStoppedEvent = (input?: Record<string, any>) => {
+decoders['CallRecordingStoppedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CallRejectedEvent = (input?: Record<string, any>) => {
+decoders['CallRejectedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -999,7 +1031,7 @@ decoders.CallRejectedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallReportResponse = (input?: Record<string, any>) => {
+decoders['CallReportResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     ended_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1008,7 +1040,7 @@ decoders.CallReportResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallResponse = (input?: Record<string, any>) => {
+decoders['CallResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1027,7 +1059,7 @@ decoders.CallResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallRingEvent = (input?: Record<string, any>) => {
+decoders['CallRingEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1040,28 +1072,32 @@ decoders.CallRingEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallRtmpBroadcastFailedEvent = (input?: Record<string, any>) => {
+decoders['CallRtmpBroadcastFailedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CallRtmpBroadcastStartedEvent = (input?: Record<string, any>) => {
+decoders['CallRtmpBroadcastStartedEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CallRtmpBroadcastStoppedEvent = (input?: Record<string, any>) => {
+decoders['CallRtmpBroadcastStoppedEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CallSessionEndedEvent = (input?: Record<string, any>) => {
+decoders['CallSessionEndedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1070,25 +1106,18 @@ decoders.CallSessionEndedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallSessionParticipantCountsUpdatedEvent = (
-  input?: Record<string, any>,
-) => {
+decoders['CallSessionParticipantCountsUpdatedEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CallSessionParticipantJoinedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    participant: { type: 'CallParticipantResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CallSessionParticipantLeftEvent = (input?: Record<string, any>) => {
+decoders['CallSessionParticipantJoinedEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1097,7 +1126,18 @@ decoders.CallSessionParticipantLeftEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallSessionResponse = (input?: Record<string, any>) => {
+decoders['CallSessionParticipantLeftEvent'] = (input?: {
+  [key: string]: any;
+}) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    participant: { type: 'CallParticipantResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['CallSessionResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     participants: { type: 'CallParticipantResponse', isSingle: false },
 
@@ -1120,7 +1160,7 @@ decoders.CallSessionResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallSessionStartedEvent = (input?: Record<string, any>) => {
+decoders['CallSessionStartedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1129,7 +1169,7 @@ decoders.CallSessionStartedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallStateResponseFields = (input?: Record<string, any>) => {
+decoders['CallStateResponseFields'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     members: { type: 'MemberResponse', isSingle: false },
 
@@ -1138,7 +1178,7 @@ decoders.CallStateResponseFields = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallStatsParticipant = (input?: Record<string, any>) => {
+decoders['CallStatsParticipant'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     sessions: { type: 'CallStatsParticipantSession', isSingle: false },
 
@@ -1147,7 +1187,7 @@ decoders.CallStatsParticipant = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallStatsParticipantSession = (input?: Record<string, any>) => {
+decoders['CallStatsParticipantSession'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     ended_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1156,7 +1196,7 @@ decoders.CallStatsParticipantSession = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallStatsReportReadyEvent = (input?: Record<string, any>) => {
+decoders['CallStatsReportReadyEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1165,7 +1205,9 @@ decoders.CallStatsReportReadyEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallStatsReportSummaryResponse = (input?: Record<string, any>) => {
+decoders['CallStatsReportSummaryResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     first_stats_time: { type: 'DatetimeType', isSingle: true },
 
@@ -1174,7 +1216,7 @@ decoders.CallStatsReportSummaryResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallStatsSessionResponse = (input?: Record<string, any>) => {
+decoders['CallStatsSessionResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     generated_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1185,7 +1227,7 @@ decoders.CallStatsSessionResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallTranscription = (input?: Record<string, any>) => {
+decoders['CallTranscription'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     end_time: { type: 'DatetimeType', isSingle: true },
 
@@ -1194,14 +1236,14 @@ decoders.CallTranscription = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallTranscriptionFailedEvent = (input?: Record<string, any>) => {
+decoders['CallTranscriptionFailedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CallTranscriptionReadyEvent = (input?: Record<string, any>) => {
+decoders['CallTranscriptionReadyEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1210,30 +1252,25 @@ decoders.CallTranscriptionReadyEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallTranscriptionStartedEvent = (input?: Record<string, any>) => {
+decoders['CallTranscriptionStartedEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CallTranscriptionStoppedEvent = (input?: Record<string, any>) => {
+decoders['CallTranscriptionStoppedEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CallType = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CallTypeResponse = (input?: Record<string, any>) => {
+decoders['CallType'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1242,7 +1279,16 @@ decoders.CallTypeResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallUpdatedEvent = (input?: Record<string, any>) => {
+decoders['CallTypeResponse'] = (input?: { [key: string]: any }) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['CallUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1251,7 +1297,9 @@ decoders.CallUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallUserFeedbackSubmittedEvent = (input?: Record<string, any>) => {
+decoders['CallUserFeedbackSubmittedEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1260,14 +1308,14 @@ decoders.CallUserFeedbackSubmittedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CallUserMutedEvent = (input?: Record<string, any>) => {
+decoders['CallUserMutedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CampaignCompletedEvent = (input?: Record<string, any>) => {
+decoders['CampaignCompletedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1278,7 +1326,7 @@ decoders.CampaignCompletedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CampaignResponse = (input?: Record<string, any>) => {
+decoders['CampaignResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1299,7 +1347,7 @@ decoders.CampaignResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CampaignStartedEvent = (input?: Record<string, any>) => {
+decoders['CampaignStartedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1310,7 +1358,7 @@ decoders.CampaignStartedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CampaignStatsResponse = (input?: Record<string, any>) => {
+decoders['CampaignStatsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     stats_completed_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1319,14 +1367,14 @@ decoders.CampaignStatsResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChangeFeedVisibilityResponse = (input?: Record<string, any>) => {
+decoders['ChangeFeedVisibilityResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     feed: { type: 'FeedResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ChannelBatchCompletedEvent = (input?: Record<string, any>) => {
+decoders['ChannelBatchCompletedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     batch_created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1339,7 +1387,7 @@ decoders.ChannelBatchCompletedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChannelBatchStartedEvent = (input?: Record<string, any>) => {
+decoders['ChannelBatchStartedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     batch_created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1352,7 +1400,7 @@ decoders.ChannelBatchStartedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChannelConfig = (input?: Record<string, any>) => {
+decoders['ChannelConfig'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1361,7 +1409,7 @@ decoders.ChannelConfig = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChannelConfigWithInfo = (input?: Record<string, any>) => {
+decoders['ChannelConfigWithInfo'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1372,14 +1420,14 @@ decoders.ChannelConfigWithInfo = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChannelContextResponse = (input?: Record<string, any>) => {
+decoders['ChannelContextResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_by: { type: 'UserResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ChannelCreatedEvent = (input?: Record<string, any>) => {
+decoders['ChannelCreatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1392,7 +1440,7 @@ decoders.ChannelCreatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChannelDeletedEvent = (input?: Record<string, any>) => {
+decoders['ChannelDeletedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1405,7 +1453,7 @@ decoders.ChannelDeletedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChannelFrozenEvent = (input?: Record<string, any>) => {
+decoders['ChannelFrozenEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1414,7 +1462,7 @@ decoders.ChannelFrozenEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChannelHiddenEvent = (input?: Record<string, any>) => {
+decoders['ChannelHiddenEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1427,7 +1475,7 @@ decoders.ChannelHiddenEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChannelMemberResponse = (input?: Record<string, any>) => {
+decoders['ChannelMemberResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1452,14 +1500,14 @@ decoders.ChannelMemberResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChannelMetadata = (input?: Record<string, any>) => {
+decoders['ChannelMetadata'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     last_message_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ChannelMute = (input?: Record<string, any>) => {
+decoders['ChannelMute'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1474,7 +1522,7 @@ decoders.ChannelMute = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChannelMutedEvent = (input?: Record<string, any>) => {
+decoders['ChannelMutedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1489,14 +1537,16 @@ decoders.ChannelMutedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChannelPushPreferencesResponse = (input?: Record<string, any>) => {
+decoders['ChannelPushPreferencesResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     disabled_until: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ChannelResponse = (input?: Record<string, any>) => {
+decoders['ChannelResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1523,7 +1573,7 @@ decoders.ChannelResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChannelStateResponse = (input?: Record<string, any>) => {
+decoders['ChannelStateResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     members: { type: 'ChannelMemberResponse', isSingle: false },
 
@@ -1560,7 +1610,7 @@ decoders.ChannelStateResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChannelStateResponseFields = (input?: Record<string, any>) => {
+decoders['ChannelStateResponseFields'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     members: { type: 'ChannelMemberResponse', isSingle: false },
 
@@ -1597,7 +1647,7 @@ decoders.ChannelStateResponseFields = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChannelTruncatedEvent = (input?: Record<string, any>) => {
+decoders['ChannelTruncatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1612,7 +1662,7 @@ decoders.ChannelTruncatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChannelTypeConfig = (input?: Record<string, any>) => {
+decoders['ChannelTypeConfig'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1623,7 +1673,7 @@ decoders.ChannelTypeConfig = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChannelUnFrozenEvent = (input?: Record<string, any>) => {
+decoders['ChannelUnFrozenEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1632,7 +1682,7 @@ decoders.ChannelUnFrozenEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChannelUnmutedEvent = (input?: Record<string, any>) => {
+decoders['ChannelUnmutedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1647,7 +1697,7 @@ decoders.ChannelUnmutedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChannelUpdatedEvent = (input?: Record<string, any>) => {
+decoders['ChannelUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1662,7 +1712,7 @@ decoders.ChannelUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChannelVisibleEvent = (input?: Record<string, any>) => {
+decoders['ChannelVisibleEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1675,21 +1725,21 @@ decoders.ChannelVisibleEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChatActivityStatsResponse = (input?: Record<string, any>) => {
+decoders['ChatActivityStatsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     messages: { type: 'MessageStatsResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ChatDraftPayloadResponse = (input?: Record<string, any>) => {
+decoders['ChatDraftPayloadResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     mentioned_users: { type: 'UserResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ChatDraftResponse = (input?: Record<string, any>) => {
+decoders['ChatDraftResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1702,7 +1752,7 @@ decoders.ChatDraftResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChatMessageResponse = (input?: Record<string, any>) => {
+decoders['ChatMessageResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1745,7 +1795,7 @@ decoders.ChatMessageResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChatReactionGroupResponse = (input?: Record<string, any>) => {
+decoders['ChatReactionGroupResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     first_reaction_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1759,7 +1809,9 @@ decoders.ChatReactionGroupResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChatReactionGroupUserResponse = (input?: Record<string, any>) => {
+decoders['ChatReactionGroupUserResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1768,7 +1820,7 @@ decoders.ChatReactionGroupUserResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChatReactionResponse = (input?: Record<string, any>) => {
+decoders['ChatReactionResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1779,7 +1831,7 @@ decoders.ChatReactionResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChatReminderResponseData = (input?: Record<string, any>) => {
+decoders['ChatReminderResponseData'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1794,7 +1846,9 @@ decoders.ChatReminderResponseData = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ChatSharedLocationResponseData = (input?: Record<string, any>) => {
+decoders['ChatSharedLocationResponseData'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1807,14 +1861,14 @@ decoders.ChatSharedLocationResponseData = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CheckResponse = (input?: Record<string, any>) => {
+decoders['CheckResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     item: { type: 'ReviewQueueItemResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ClientEvent = (input?: Record<string, any>) => {
+decoders['ClientEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     previously_connected_timestamp: { type: 'DatetimeType', isSingle: true },
 
@@ -1823,23 +1877,14 @@ decoders.ClientEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ClosedCaptionEvent = (input?: Record<string, any>) => {
+decoders['ClosedCaptionEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CollectionResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.Command = (input?: Record<string, any>) => {
+decoders['CollectionResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1848,7 +1893,16 @@ decoders.Command = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CommentAddedEvent = (input?: Record<string, any>) => {
+decoders['Command'] = (input?: { [key: string]: any }) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['CommentAddedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1863,7 +1917,7 @@ decoders.CommentAddedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CommentDeletedEvent = (input?: Record<string, any>) => {
+decoders['CommentDeletedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1876,37 +1930,7 @@ decoders.CommentDeletedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CommentReactionAddedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    activity: { type: 'ActivityResponse', isSingle: true },
-
-    comment: { type: 'CommentResponse', isSingle: true },
-
-    reaction: { type: 'FeedsReactionResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-
-    user: { type: 'UserResponseCommonFields', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CommentReactionDeletedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    comment: { type: 'CommentResponse', isSingle: true },
-
-    reaction: { type: 'FeedsReactionResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.CommentReactionUpdatedEvent = (input?: Record<string, any>) => {
+decoders['CommentReactionAddedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1923,7 +1947,37 @@ decoders.CommentReactionUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CommentResponse = (input?: Record<string, any>) => {
+decoders['CommentReactionDeletedEvent'] = (input?: { [key: string]: any }) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    comment: { type: 'CommentResponse', isSingle: true },
+
+    reaction: { type: 'FeedsReactionResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['CommentReactionUpdatedEvent'] = (input?: { [key: string]: any }) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    activity: { type: 'ActivityResponse', isSingle: true },
+
+    comment: { type: 'CommentResponse', isSingle: true },
+
+    reaction: { type: 'FeedsReactionResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+
+    user: { type: 'UserResponseCommonFields', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['CommentResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1946,7 +2000,7 @@ decoders.CommentResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CommentRestoredEvent = (input?: Record<string, any>) => {
+decoders['CommentRestoredEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1959,7 +2013,7 @@ decoders.CommentRestoredEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CommentUpdatedEvent = (input?: Record<string, any>) => {
+decoders['CommentUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1972,7 +2026,7 @@ decoders.CommentUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ConfigResponse = (input?: Record<string, any>) => {
+decoders['ConfigResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -1981,21 +2035,21 @@ decoders.ConfigResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CountByMinuteResponse = (input?: Record<string, any>) => {
+decoders['CountByMinuteResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     start_ts: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CreateBlockListResponse = (input?: Record<string, any>) => {
+decoders['CreateBlockListResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     blocklist: { type: 'BlockListResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CreateCallTypeResponse = (input?: Record<string, any>) => {
+decoders['CreateCallTypeResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2004,14 +2058,14 @@ decoders.CreateCallTypeResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CreateCampaignResponse = (input?: Record<string, any>) => {
+decoders['CreateCampaignResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     campaign: { type: 'CampaignResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CreateChannelTypeResponse = (input?: Record<string, any>) => {
+decoders['CreateChannelTypeResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2020,56 +2074,56 @@ decoders.CreateChannelTypeResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CreateCollectionsResponse = (input?: Record<string, any>) => {
+decoders['CreateCollectionsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     collections: { type: 'CollectionResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CreateCommandResponse = (input?: Record<string, any>) => {
+decoders['CreateCommandResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     command: { type: 'Command', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CreateFeedGroupResponse = (input?: Record<string, any>) => {
+decoders['CreateFeedGroupResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     feed_group: { type: 'FeedGroupResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CreateFeedViewResponse = (input?: Record<string, any>) => {
+decoders['CreateFeedViewResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     feed_view: { type: 'FeedViewResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CreateFeedsBatchResponse = (input?: Record<string, any>) => {
+decoders['CreateFeedsBatchResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     feeds: { type: 'FeedResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CreateGuestResponse = (input?: Record<string, any>) => {
+decoders['CreateGuestResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     user: { type: 'UserResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CreateImportResponse = (input?: Record<string, any>) => {
+decoders['CreateImportResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     import_task: { type: 'ImportTask', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CreateImportV2TaskResponse = (input?: Record<string, any>) => {
+decoders['CreateImportV2TaskResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2078,49 +2132,60 @@ decoders.CreateImportV2TaskResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CreateMembershipLevelResponse = (input?: Record<string, any>) => {
+decoders['CreateMembershipLevelResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     membership_level: { type: 'MembershipLevelResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CreateRoleResponse = (input?: Record<string, any>) => {
+decoders['CreatePredefinedFilterResponse'] = (input?: {
+  [key: string]: any;
+}) => {
+  const typeMappings: TypeMapping = {
+    predefined_filter: { type: 'PredefinedFilterResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['CreateRoleResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     role: { type: 'Role', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CreateSIPTrunkResponse = (input?: Record<string, any>) => {
+decoders['CreateSIPTrunkResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     sip_trunk: { type: 'SIPTrunkResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CreateSegmentResponse = (input?: Record<string, any>) => {
+decoders['CreateSegmentResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     segment: { type: 'SegmentResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CreateUserGroupResponse = (input?: Record<string, any>) => {
+decoders['CreateUserGroupResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     user_group: { type: 'UserGroupResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CustomCheckResponse = (input?: Record<string, any>) => {
+decoders['CustomCheckResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     item: { type: 'ReviewQueueItemResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.CustomEvent = (input?: Record<string, any>) => {
+decoders['CustomEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2129,7 +2194,7 @@ decoders.CustomEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.CustomVideoEvent = (input?: Record<string, any>) => {
+decoders['CustomVideoEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2138,14 +2203,16 @@ decoders.CustomVideoEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.DeactivateUserResponse = (input?: Record<string, any>) => {
+decoders['DeactivateUserResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     user: { type: 'UserResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.DeleteActivityReactionResponse = (input?: Record<string, any>) => {
+decoders['DeleteActivityReactionResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     activity: { type: 'ActivityResponse', isSingle: true },
 
@@ -2154,35 +2221,39 @@ decoders.DeleteActivityReactionResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.DeleteBookmarkResponse = (input?: Record<string, any>) => {
+decoders['DeleteBookmarkResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     bookmark: { type: 'BookmarkResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.DeleteCallResponse = (input?: Record<string, any>) => {
+decoders['DeleteCallResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     call: { type: 'CallResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.DeleteChannelResponse = (input?: Record<string, any>) => {
+decoders['DeleteChannelResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     channel: { type: 'ChannelResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.DeleteCommentBookmarkResponse = (input?: Record<string, any>) => {
+decoders['DeleteCommentBookmarkResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     bookmark: { type: 'BookmarkResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.DeleteCommentReactionResponse = (input?: Record<string, any>) => {
+decoders['DeleteCommentReactionResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     comment: { type: 'CommentResponse', isSingle: true },
 
@@ -2191,7 +2262,7 @@ decoders.DeleteCommentReactionResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.DeleteCommentResponse = (input?: Record<string, any>) => {
+decoders['DeleteCommentResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     activity: { type: 'ActivityResponse', isSingle: true },
 
@@ -2200,14 +2271,14 @@ decoders.DeleteCommentResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.DeleteMessageResponse = (input?: Record<string, any>) => {
+decoders['DeleteMessageResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     message: { type: 'MessageResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.DeleteReactionResponse = (input?: Record<string, any>) => {
+decoders['DeleteReactionResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     message: { type: 'MessageResponse', isSingle: true },
 
@@ -2216,21 +2287,21 @@ decoders.DeleteReactionResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.DeviceResponse = (input?: Record<string, any>) => {
+decoders['DeviceResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.DraftPayloadResponse = (input?: Record<string, any>) => {
+decoders['DraftPayloadResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     mentioned_users: { type: 'UserResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.DraftResponse = (input?: Record<string, any>) => {
+decoders['DraftResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2245,21 +2316,21 @@ decoders.DraftResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.EgressRTMPResponse = (input?: Record<string, any>) => {
+decoders['EgressRTMPResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     started_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.EgressResponse = (input?: Record<string, any>) => {
+decoders['EgressResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     rtmps: { type: 'EgressRTMPResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.EnrichedCollectionResponse = (input?: Record<string, any>) => {
+decoders['EnrichedCollectionResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2268,7 +2339,7 @@ decoders.EnrichedCollectionResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.EntityCreatorResponse = (input?: Record<string, any>) => {
+decoders['EntityCreatorResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2294,7 +2365,7 @@ decoders.EntityCreatorResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.EventHook = (input?: Record<string, any>) => {
+decoders['EventHook'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2303,14 +2374,14 @@ decoders.EventHook = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.EventResponse = (input?: Record<string, any>) => {
+decoders['EventResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     event: { type: 'WSEvent', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ExportUserResponse = (input?: Record<string, any>) => {
+decoders['ExportUserResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     messages: { type: 'MessageResponse', isSingle: false },
 
@@ -2321,7 +2392,7 @@ decoders.ExportUserResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedCreatedEvent = (input?: Record<string, any>) => {
+decoders['FeedCreatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2336,7 +2407,7 @@ decoders.FeedCreatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedDeletedEvent = (input?: Record<string, any>) => {
+decoders['FeedDeletedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2347,7 +2418,7 @@ decoders.FeedDeletedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedGroupChangedEvent = (input?: Record<string, any>) => {
+decoders['FeedGroupChangedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2358,7 +2429,7 @@ decoders.FeedGroupChangedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedGroupDeletedEvent = (input?: Record<string, any>) => {
+decoders['FeedGroupDeletedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2367,7 +2438,7 @@ decoders.FeedGroupDeletedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedGroupResponse = (input?: Record<string, any>) => {
+decoders['FeedGroupResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2383,7 +2454,7 @@ decoders.FeedGroupResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedGroupRestoredEvent = (input?: Record<string, any>) => {
+decoders['FeedGroupRestoredEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2392,7 +2463,7 @@ decoders.FeedGroupRestoredEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedMemberAddedEvent = (input?: Record<string, any>) => {
+decoders['FeedMemberAddedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2405,7 +2476,7 @@ decoders.FeedMemberAddedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedMemberRemovedEvent = (input?: Record<string, any>) => {
+decoders['FeedMemberRemovedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2416,7 +2487,7 @@ decoders.FeedMemberRemovedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedMemberResponse = (input?: Record<string, any>) => {
+decoders['FeedMemberResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2433,7 +2504,7 @@ decoders.FeedMemberResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedMemberUpdatedEvent = (input?: Record<string, any>) => {
+decoders['FeedMemberUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2446,7 +2517,7 @@ decoders.FeedMemberUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedOwnData = (input?: Record<string, any>) => {
+decoders['FeedOwnData'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     own_followings: { type: 'FollowResponse', isSingle: false },
 
@@ -2457,26 +2528,7 @@ decoders.FeedOwnData = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-
-    created_by: { type: 'UserResponse', isSingle: true },
-
-    deleted_at: { type: 'DatetimeType', isSingle: true },
-
-    own_followings: { type: 'FollowResponse', isSingle: false },
-
-    own_follows: { type: 'FollowResponse', isSingle: false },
-
-    own_membership: { type: 'FeedMemberResponse', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.FeedSuggestionResponse = (input?: Record<string, any>) => {
+decoders['FeedResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2495,7 +2547,26 @@ decoders.FeedSuggestionResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedUpdatedEvent = (input?: Record<string, any>) => {
+decoders['FeedSuggestionResponse'] = (input?: { [key: string]: any }) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    created_by: { type: 'UserResponse', isSingle: true },
+
+    deleted_at: { type: 'DatetimeType', isSingle: true },
+
+    own_followings: { type: 'FollowResponse', isSingle: false },
+
+    own_follows: { type: 'FollowResponse', isSingle: false },
+
+    own_membership: { type: 'FeedMemberResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['FeedUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2508,7 +2579,7 @@ decoders.FeedUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedViewResponse = (input?: Record<string, any>) => {
+decoders['FeedViewResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     last_used_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2520,7 +2591,7 @@ decoders.FeedViewResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedsBookmarkResponse = (input?: Record<string, any>) => {
+decoders['FeedsBookmarkResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2531,7 +2602,9 @@ decoders.FeedsBookmarkResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedsEnrichedCollectionResponse = (input?: Record<string, any>) => {
+decoders['FeedsEnrichedCollectionResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2540,7 +2613,7 @@ decoders.FeedsEnrichedCollectionResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedsFeedResponse = (input?: Record<string, any>) => {
+decoders['FeedsFeedResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2553,7 +2626,7 @@ decoders.FeedsFeedResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedsReactionGroupResponse = (input?: Record<string, any>) => {
+decoders['FeedsReactionGroupResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     first_reaction_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2562,7 +2635,7 @@ decoders.FeedsReactionGroupResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedsReactionResponse = (input?: Record<string, any>) => {
+decoders['FeedsReactionResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2573,7 +2646,7 @@ decoders.FeedsReactionResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedsShareResponse = (input?: Record<string, any>) => {
+decoders['FeedsShareResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2582,7 +2655,7 @@ decoders.FeedsShareResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedsV3ActivityResponse = (input?: Record<string, any>) => {
+decoders['FeedsV3ActivityResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2623,7 +2696,7 @@ decoders.FeedsV3ActivityResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FeedsV3CommentResponse = (input?: Record<string, any>) => {
+decoders['FeedsV3CommentResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2646,21 +2719,21 @@ decoders.FeedsV3CommentResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FlagDetailsResponse = (input?: Record<string, any>) => {
+decoders['FlagDetailsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     automod: { type: 'AutomodDetailsResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.FlagFeedbackResponse = (input?: Record<string, any>) => {
+decoders['FlagFeedbackResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.FlagUpdatedEvent = (input?: Record<string, any>) => {
+decoders['FlagUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2675,7 +2748,7 @@ decoders.FlagUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FollowBatchResponse = (input?: Record<string, any>) => {
+decoders['FollowBatchResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created: { type: 'FollowResponse', isSingle: false },
 
@@ -2684,7 +2757,7 @@ decoders.FollowBatchResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FollowCreatedEvent = (input?: Record<string, any>) => {
+decoders['FollowCreatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2695,7 +2768,7 @@ decoders.FollowCreatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FollowDeletedEvent = (input?: Record<string, any>) => {
+decoders['FollowDeletedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2706,7 +2779,7 @@ decoders.FollowDeletedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FollowResponse = (input?: Record<string, any>) => {
+decoders['FollowResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2723,7 +2796,7 @@ decoders.FollowResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FollowUpdatedEvent = (input?: Record<string, any>) => {
+decoders['FollowUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2734,7 +2807,7 @@ decoders.FollowUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FullUserResponse = (input?: Record<string, any>) => {
+decoders['FullUserResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2759,7 +2832,7 @@ decoders.FullUserResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.FutureChannelBanResponse = (input?: Record<string, any>) => {
+decoders['FutureChannelBanResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2772,7 +2845,7 @@ decoders.FutureChannelBanResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.GetActiveCallsStatusResponse = (input?: Record<string, any>) => {
+decoders['GetActiveCallsStatusResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     end_time: { type: 'DatetimeType', isSingle: true },
 
@@ -2781,44 +2854,44 @@ decoders.GetActiveCallsStatusResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.GetActivityResponse = (input?: Record<string, any>) => {
+decoders['GetActivityResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     activity: { type: 'ActivityResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetAppealResponse = (input?: Record<string, any>) => {
+decoders['GetAppealResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     item: { type: 'AppealItemResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetApplicationResponse = (input?: Record<string, any>) => {
+decoders['GetApplicationResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     app: { type: 'AppResponseFields', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetBlockListResponse = (input?: Record<string, any>) => {
+decoders['GetBlockListResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     blocklist: { type: 'BlockListResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetBlockedUsersResponse = (input?: Record<string, any>) => {
+decoders['GetBlockedUsersResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     blocks: { type: 'BlockedUserResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetCallParticipantSessionMetricsResponse = (
-  input?: Record<string, any>,
-) => {
+decoders['GetCallParticipantSessionMetricsResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     joined_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2827,7 +2900,7 @@ decoders.GetCallParticipantSessionMetricsResponse = (
   return decode(typeMappings, input);
 };
 
-decoders.GetCallReportResponse = (input?: Record<string, any>) => {
+decoders['GetCallReportResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     report: { type: 'ReportResponse', isSingle: true },
 
@@ -2840,7 +2913,7 @@ decoders.GetCallReportResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.GetCallResponse = (input?: Record<string, any>) => {
+decoders['GetCallResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     members: { type: 'MemberResponse', isSingle: false },
 
@@ -2849,16 +2922,16 @@ decoders.GetCallResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.GetCallSessionParticipantStatsDetailsResponse = (
-  input?: Record<string, any>,
-) => {
+decoders['GetCallSessionParticipantStatsDetailsResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     timeframe: { type: 'ParticipantSeriesTimeframe', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetCallTypeResponse = (input?: Record<string, any>) => {
+decoders['GetCallTypeResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2867,14 +2940,14 @@ decoders.GetCallTypeResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.GetCampaignResponse = (input?: Record<string, any>) => {
+decoders['GetCampaignResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     campaign: { type: 'CampaignResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetChannelTypeResponse = (input?: Record<string, any>) => {
+decoders['GetChannelTypeResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2885,7 +2958,7 @@ decoders.GetChannelTypeResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.GetCommandResponse = (input?: Record<string, any>) => {
+decoders['GetCommandResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2894,42 +2967,42 @@ decoders.GetCommandResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.GetCommentRepliesResponse = (input?: Record<string, any>) => {
+decoders['GetCommentRepliesResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     comments: { type: 'ThreadedCommentResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetCommentResponse = (input?: Record<string, any>) => {
+decoders['GetCommentResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     comment: { type: 'CommentResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetCommentsResponse = (input?: Record<string, any>) => {
+decoders['GetCommentsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     comments: { type: 'ThreadedCommentResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetConfigResponse = (input?: Record<string, any>) => {
+decoders['GetConfigResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     config: { type: 'ConfigResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetDraftResponse = (input?: Record<string, any>) => {
+decoders['GetDraftResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     draft: { type: 'DraftResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetExternalStorageResponse = (input?: Record<string, any>) => {
+decoders['GetExternalStorageResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2938,35 +3011,35 @@ decoders.GetExternalStorageResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.GetFeedGroupResponse = (input?: Record<string, any>) => {
+decoders['GetFeedGroupResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     feed_group: { type: 'FeedGroupResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetFeedViewResponse = (input?: Record<string, any>) => {
+decoders['GetFeedViewResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     feed_view: { type: 'FeedViewResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetFollowSuggestionsResponse = (input?: Record<string, any>) => {
+decoders['GetFollowSuggestionsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     suggestions: { type: 'FeedSuggestionResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetImportResponse = (input?: Record<string, any>) => {
+decoders['GetImportResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     import_task: { type: 'ImportTask', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetImportV2TaskResponse = (input?: Record<string, any>) => {
+decoders['GetImportV2TaskResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -2975,28 +3048,28 @@ decoders.GetImportV2TaskResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.GetManyMessagesResponse = (input?: Record<string, any>) => {
+decoders['GetManyMessagesResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     messages: { type: 'MessageResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetMessageResponse = (input?: Record<string, any>) => {
+decoders['GetMessageResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     message: { type: 'MessageWithChannelResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetModerationRuleResponse = (input?: Record<string, any>) => {
+decoders['GetModerationRuleResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     rule: { type: 'ModerationRuleV2Response', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetOrCreateCallResponse = (input?: Record<string, any>) => {
+decoders['GetOrCreateCallResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     members: { type: 'MemberResponse', isSingle: false },
 
@@ -3005,14 +3078,14 @@ decoders.GetOrCreateCallResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.GetOrCreateFeedGroupResponse = (input?: Record<string, any>) => {
+decoders['GetOrCreateFeedGroupResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     feed_group: { type: 'FeedGroupResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetOrCreateFeedResponse = (input?: Record<string, any>) => {
+decoders['GetOrCreateFeedResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     activities: { type: 'ActivityResponse', isSingle: false },
 
@@ -3036,77 +3109,91 @@ decoders.GetOrCreateFeedResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.GetOrCreateFeedViewResponse = (input?: Record<string, any>) => {
+decoders['GetOrCreateFeedViewResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     feed_view: { type: 'FeedViewResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetOrCreateFollowResponse = (input?: Record<string, any>) => {
+decoders['GetOrCreateFollowResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     follow: { type: 'FollowResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetOrCreateUnfollowResponse = (input?: Record<string, any>) => {
+decoders['GetOrCreateUnfollowResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     follow: { type: 'FollowResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetPushTemplatesResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    templates: { type: 'PushTemplateResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.GetReactionsResponse = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    reactions: { type: 'ReactionResponse', isSingle: false },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.GetRepliesResponse = (input?: Record<string, any>) => {
+decoders['GetPinnedMessagesResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     messages: { type: 'MessageResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetRetentionPolicyResponse = (input?: Record<string, any>) => {
+decoders['GetPredefinedFilterResponse'] = (input?: { [key: string]: any }) => {
+  const typeMappings: TypeMapping = {
+    predefined_filter: { type: 'PredefinedFilterResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['GetPushTemplatesResponse'] = (input?: { [key: string]: any }) => {
+  const typeMappings: TypeMapping = {
+    templates: { type: 'PushTemplateResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['GetReactionsResponse'] = (input?: { [key: string]: any }) => {
+  const typeMappings: TypeMapping = {
+    reactions: { type: 'ReactionResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['GetRepliesResponse'] = (input?: { [key: string]: any }) => {
+  const typeMappings: TypeMapping = {
+    messages: { type: 'MessageResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['GetRetentionPolicyResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     policies: { type: 'RetentionPolicy', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetReviewQueueItemResponse = (input?: Record<string, any>) => {
+decoders['GetReviewQueueItemResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     item: { type: 'ReviewQueueItemResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetSegmentResponse = (input?: Record<string, any>) => {
+decoders['GetSegmentResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     segment: { type: 'SegmentResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetSetupSessionResponse = (input?: Record<string, any>) => {
+decoders['GetSetupSessionResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     setup_session: { type: 'SetupSession', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetTaskResponse = (input?: Record<string, any>) => {
+decoders['GetTaskResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3115,42 +3202,42 @@ decoders.GetTaskResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.GetThreadResponse = (input?: Record<string, any>) => {
+decoders['GetThreadResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     thread: { type: 'ThreadStateResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GetUserGroupResponse = (input?: Record<string, any>) => {
+decoders['GetUserGroupResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     user_group: { type: 'UserGroupResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GoLiveResponse = (input?: Record<string, any>) => {
+decoders['GoLiveResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     call: { type: 'CallResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GroupedChannelsBucket = (input?: Record<string, any>) => {
+decoders['GroupedChannelsBucket'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     channels: { type: 'ChannelStateResponseFields', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.GroupedQueryChannelsResponse = (input?: Record<string, any>) => {
+decoders['GroupedQueryChannelsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     groups: { type: 'GroupedChannelsBucket', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ImportTask = (input?: Record<string, any>) => {
+decoders['ImportTask'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3161,14 +3248,14 @@ decoders.ImportTask = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ImportTaskHistory = (input?: Record<string, any>) => {
+decoders['ImportTaskHistory'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ImportV2TaskItem = (input?: Record<string, any>) => {
+decoders['ImportV2TaskItem'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3177,28 +3264,28 @@ decoders.ImportV2TaskItem = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.IngressErrorEvent = (input?: Record<string, any>) => {
+decoders['IngressErrorEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.IngressStartedEvent = (input?: Record<string, any>) => {
+decoders['IngressStartedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.IngressStoppedEvent = (input?: Record<string, any>) => {
+decoders['IngressStoppedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.KickedUserEvent = (input?: Record<string, any>) => {
+decoders['KickedUserEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3209,105 +3296,107 @@ decoders.KickedUserEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.LabelResultResponse = (input?: Record<string, any>) => {
+decoders['LabelResultResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ListBlockListResponse = (input?: Record<string, any>) => {
+decoders['ListBlockListResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     blocklists: { type: 'BlockListResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ListCallTypeResponse = (input?: Record<string, any>) => {
+decoders['ListCallTypeResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     call_types: { type: 'CallTypeResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ListChannelTypesResponse = (input?: Record<string, any>) => {
+decoders['ListChannelTypesResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     channel_types: { type: 'ChannelTypeConfig', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ListCommandsResponse = (input?: Record<string, any>) => {
+decoders['ListCommandsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     commands: { type: 'Command', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ListDevicesResponse = (input?: Record<string, any>) => {
+decoders['ListDevicesResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     devices: { type: 'DeviceResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ListFeedGroupsResponse = (input?: Record<string, any>) => {
+decoders['ListFeedGroupsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     groups: { type: 'FeedGroupResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ListFeedViewsResponse = (input?: Record<string, any>) => {
+decoders['ListFeedViewsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     views: { type: 'FeedViewResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ListImportV2TasksResponse = (input?: Record<string, any>) => {
+decoders['ListImportV2TasksResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     import_tasks: { type: 'ImportV2TaskItem', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ListImportsResponse = (input?: Record<string, any>) => {
+decoders['ListImportsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     import_tasks: { type: 'ImportTask', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ListPushProvidersResponse = (input?: Record<string, any>) => {
+decoders['ListPushProvidersResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     push_providers: { type: 'PushProviderResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ListQueuesResponse = (input?: Record<string, any>) => {
+decoders['ListQueuesResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     queues: { type: 'ModerationQueueResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ListRecordingsResponse = (input?: Record<string, any>) => {
+decoders['ListRecordingsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     recordings: { type: 'CallRecording', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ListRolesResponse = (input?: Record<string, any>) => {
+decoders['ListRolesResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     roles: { type: 'Role', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ListSIPInboundRoutingRuleResponse = (input?: Record<string, any>) => {
+decoders['ListSIPInboundRoutingRuleResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     sip_inbound_routing_rules: {
       type: 'SIPInboundRoutingRuleResponse',
@@ -3317,35 +3406,35 @@ decoders.ListSIPInboundRoutingRuleResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ListSIPTrunksResponse = (input?: Record<string, any>) => {
+decoders['ListSIPTrunksResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     sip_trunks: { type: 'SIPTrunkResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ListTranscriptionsResponse = (input?: Record<string, any>) => {
+decoders['ListTranscriptionsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     transcriptions: { type: 'CallTranscription', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ListUserGroupsResponse = (input?: Record<string, any>) => {
+decoders['ListUserGroupsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     user_groups: { type: 'UserGroupResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.MarkReadResponse = (input?: Record<string, any>) => {
+decoders['MarkReadResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     event: { type: 'MarkReadResponseEvent', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.MarkReadResponseEvent = (input?: Record<string, any>) => {
+decoders['MarkReadResponseEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3360,7 +3449,7 @@ decoders.MarkReadResponseEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.MaxStreakChangedEvent = (input?: Record<string, any>) => {
+decoders['MaxStreakChangedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3369,22 +3458,7 @@ decoders.MaxStreakChangedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.MemberAddedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    channel: { type: 'ChannelResponse', isSingle: true },
-
-    member: { type: 'ChannelMemberResponse', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-
-    user: { type: 'UserResponseCommonFields', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.MemberRemovedEvent = (input?: Record<string, any>) => {
+decoders['MemberAddedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3399,7 +3473,22 @@ decoders.MemberRemovedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.MemberResponse = (input?: Record<string, any>) => {
+decoders['MemberRemovedEvent'] = (input?: { [key: string]: any }) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    channel: { type: 'ChannelResponse', isSingle: true },
+
+    member: { type: 'ChannelMemberResponse', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+
+    user: { type: 'UserResponseCommonFields', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['MemberResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3412,7 +3501,7 @@ decoders.MemberResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.MemberUpdatedEvent = (input?: Record<string, any>) => {
+decoders['MemberUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3427,14 +3516,14 @@ decoders.MemberUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.MembersResponse = (input?: Record<string, any>) => {
+decoders['MembersResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     members: { type: 'ChannelMemberResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.MembershipLevelResponse = (input?: Record<string, any>) => {
+decoders['MembershipLevelResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3443,14 +3532,14 @@ decoders.MembershipLevelResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.MessageActionResponse = (input?: Record<string, any>) => {
+decoders['MessageActionResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     message: { type: 'MessageResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.MessageDeletedEvent = (input?: Record<string, any>) => {
+decoders['MessageDeletedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3463,7 +3552,7 @@ decoders.MessageDeletedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.MessageFlagResponse = (input?: Record<string, any>) => {
+decoders['MessageFlagResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3490,7 +3579,7 @@ decoders.MessageFlagResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.MessageFlaggedEvent = (input?: Record<string, any>) => {
+decoders['MessageFlaggedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3505,14 +3594,14 @@ decoders.MessageFlaggedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.MessageHistoryEntryResponse = (input?: Record<string, any>) => {
+decoders['MessageHistoryEntryResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     message_updated_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.MessageModerationResult = (input?: Record<string, any>) => {
+decoders['MessageModerationResult'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3521,7 +3610,7 @@ decoders.MessageModerationResult = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.MessageNewEvent = (input?: Record<string, any>) => {
+decoders['MessageNewEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3538,7 +3627,7 @@ decoders.MessageNewEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.MessageReadEvent = (input?: Record<string, any>) => {
+decoders['MessageReadEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3553,7 +3642,7 @@ decoders.MessageReadEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.MessageResponse = (input?: Record<string, any>) => {
+decoders['MessageResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3596,14 +3685,14 @@ decoders.MessageResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.MessageStatsResponse = (input?: Record<string, any>) => {
+decoders['MessageStatsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     count_over_time: { type: 'CountByMinuteResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.MessageUnblockedEvent = (input?: Record<string, any>) => {
+decoders['MessageUnblockedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3616,7 +3705,7 @@ decoders.MessageUnblockedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.MessageUndeletedEvent = (input?: Record<string, any>) => {
+decoders['MessageUndeletedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3627,7 +3716,7 @@ decoders.MessageUndeletedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.MessageUpdatedEvent = (input?: Record<string, any>) => {
+decoders['MessageUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3640,7 +3729,7 @@ decoders.MessageUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.MessageWithChannelResponse = (input?: Record<string, any>) => {
+decoders['MessageWithChannelResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3685,7 +3774,9 @@ decoders.MessageWithChannelResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ModerationAnalysisFailedEvent = (input?: Record<string, any>) => {
+decoders['ModerationAnalysisFailedEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3694,7 +3785,7 @@ decoders.ModerationAnalysisFailedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ModerationCallResponse = (input?: Record<string, any>) => {
+decoders['ModerationCallResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3709,7 +3800,9 @@ decoders.ModerationCallResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ModerationCheckCompletedEvent = (input?: Record<string, any>) => {
+decoders['ModerationCheckCompletedEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3718,7 +3811,7 @@ decoders.ModerationCheckCompletedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ModerationCustomActionEvent = (input?: Record<string, any>) => {
+decoders['ModerationCustomActionEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3731,7 +3824,7 @@ decoders.ModerationCustomActionEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ModerationFlagResponse = (input?: Record<string, any>) => {
+decoders['ModerationFlagResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3744,7 +3837,7 @@ decoders.ModerationFlagResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ModerationFlaggedEvent = (input?: Record<string, any>) => {
+decoders['ModerationFlaggedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3753,9 +3846,9 @@ decoders.ModerationFlaggedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ModerationImageAnalysisCompleteEvent = (
-  input?: Record<string, any>,
-) => {
+decoders['ModerationImageAnalysisCompleteEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3764,7 +3857,7 @@ decoders.ModerationImageAnalysisCompleteEvent = (
   return decode(typeMappings, input);
 };
 
-decoders.ModerationMarkReviewedEvent = (input?: Record<string, any>) => {
+decoders['ModerationMarkReviewedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3777,7 +3870,7 @@ decoders.ModerationMarkReviewedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ModerationQueueResponse = (input?: Record<string, any>) => {
+decoders['ModerationQueueResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3786,7 +3879,7 @@ decoders.ModerationQueueResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ModerationRuleV2Response = (input?: Record<string, any>) => {
+decoders['ModerationRuleV2Response'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3795,7 +3888,9 @@ decoders.ModerationRuleV2Response = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ModerationRulesTriggeredEvent = (input?: Record<string, any>) => {
+decoders['ModerationRulesTriggeredEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3804,9 +3899,9 @@ decoders.ModerationRulesTriggeredEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ModerationTextAnalysisCompleteEvent = (
-  input?: Record<string, any>,
-) => {
+decoders['ModerationTextAnalysisCompleteEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3815,7 +3910,7 @@ decoders.ModerationTextAnalysisCompleteEvent = (
   return decode(typeMappings, input);
 };
 
-decoders.MuteChannelResponse = (input?: Record<string, any>) => {
+decoders['MuteChannelResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     channel_mutes: { type: 'ChannelMute', isSingle: false },
 
@@ -3826,7 +3921,7 @@ decoders.MuteChannelResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.MuteResponse = (input?: Record<string, any>) => {
+decoders['MuteResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     mutes: { type: 'UserMuteResponse', isSingle: false },
 
@@ -3835,7 +3930,7 @@ decoders.MuteResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.NotificationFeedUpdatedEvent = (input?: Record<string, any>) => {
+decoders['NotificationFeedUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3853,7 +3948,7 @@ decoders.NotificationFeedUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.NotificationMarkUnreadEvent = (input?: Record<string, any>) => {
+decoders['NotificationMarkUnreadEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3868,7 +3963,7 @@ decoders.NotificationMarkUnreadEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.NotificationStatusResponse = (input?: Record<string, any>) => {
+decoders['NotificationStatusResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     last_read_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3877,7 +3972,9 @@ decoders.NotificationStatusResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.NotificationThreadMessageNewEvent = (input?: Record<string, any>) => {
+decoders['NotificationThreadMessageNewEvent'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3892,14 +3989,14 @@ decoders.NotificationThreadMessageNewEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.OwnBatchResponse = (input?: Record<string, any>) => {
+decoders['OwnBatchResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     data: { type: 'FeedOwnData', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.OwnUserResponse = (input?: Record<string, any>) => {
+decoders['OwnUserResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3924,21 +4021,25 @@ decoders.OwnUserResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ParticipantCountByMinuteResponse = (input?: Record<string, any>) => {
+decoders['ParticipantCountByMinuteResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     start_ts: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ParticipantCountOverTimeResponse = (input?: Record<string, any>) => {
+decoders['ParticipantCountOverTimeResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     by_minute: { type: 'ParticipantCountByMinuteResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ParticipantReportResponse = (input?: Record<string, any>) => {
+decoders['ParticipantReportResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     count_over_time: {
       type: 'ParticipantCountOverTimeResponse',
@@ -3948,7 +4049,7 @@ decoders.ParticipantReportResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ParticipantSeriesTimeframe = (input?: Record<string, any>) => {
+decoders['ParticipantSeriesTimeframe'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     since: { type: 'DatetimeType', isSingle: true },
 
@@ -3957,7 +4058,7 @@ decoders.ParticipantSeriesTimeframe = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ParticipantSessionDetails = (input?: Record<string, any>) => {
+decoders['ParticipantSessionDetails'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     joined_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3966,7 +4067,7 @@ decoders.ParticipantSessionDetails = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.PendingMessageEvent = (input?: Record<string, any>) => {
+decoders['PendingMessageEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -3981,7 +4082,7 @@ decoders.PendingMessageEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.PendingMessageResponse = (input?: Record<string, any>) => {
+decoders['PendingMessageResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     channel: { type: 'ChannelResponse', isSingle: true },
 
@@ -3992,7 +4093,14 @@ decoders.PendingMessageResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.PermissionRequestEvent = (input?: Record<string, any>) => {
+decoders['PerformanceAnalysisResponse'] = (input?: { [key: string]: any }) => {
+  const typeMappings: TypeMapping = {
+    last_analyzed: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['PermissionRequestEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4001,7 +4109,7 @@ decoders.PermissionRequestEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.PinActivityResponse = (input?: Record<string, any>) => {
+decoders['PinActivityResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4010,14 +4118,14 @@ decoders.PinActivityResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.PolicyTestResult = (input?: Record<string, any>) => {
+decoders['PolicyTestResult'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.PolicyTestRun = (input?: Record<string, any>) => {
+decoders['PolicyTestRun'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4030,7 +4138,7 @@ decoders.PolicyTestRun = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.PolicyTestRunResponse = (input?: Record<string, any>) => {
+decoders['PolicyTestRunResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     results: { type: 'PolicyTestResult', isSingle: false },
 
@@ -4039,7 +4147,7 @@ decoders.PolicyTestRunResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.PolicyTestSet = (input?: Record<string, any>) => {
+decoders['PolicyTestSet'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4050,14 +4158,14 @@ decoders.PolicyTestSet = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.PolicyTestSetListResponse = (input?: Record<string, any>) => {
+decoders['PolicyTestSetListResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     sets: { type: 'PolicyTestSet', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.PolicyTestSetResponse = (input?: Record<string, any>) => {
+decoders['PolicyTestSetResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     recent_runs: { type: 'PolicyTestRun', isSingle: false },
 
@@ -4066,14 +4174,14 @@ decoders.PolicyTestSetResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.PollResponse = (input?: Record<string, any>) => {
+decoders['PollResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     poll: { type: 'PollResponseData', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.PollResponseData = (input?: Record<string, any>) => {
+decoders['PollResponseData'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4088,7 +4196,7 @@ decoders.PollResponseData = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.PollVoteResponse = (input?: Record<string, any>) => {
+decoders['PollVoteResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     poll: { type: 'PollResponseData', isSingle: true },
 
@@ -4097,7 +4205,7 @@ decoders.PollVoteResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.PollVoteResponseData = (input?: Record<string, any>) => {
+decoders['PollVoteResponseData'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4108,42 +4216,66 @@ decoders.PollVoteResponseData = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.PollVotesResponse = (input?: Record<string, any>) => {
+decoders['PollVotesResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     votes: { type: 'PollVoteResponseData', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.PublishedTrackMetrics = (input?: Record<string, any>) => {
+decoders['PredefinedFilterResponse'] = (input?: { [key: string]: any }) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+
+    performance: { type: 'PerformanceAnalysisResponse', isSingle: true },
+
+    stats: { type: 'PredefinedFilterStatsResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['PredefinedFilterStatsResponse'] = (input?: {
+  [key: string]: any;
+}) => {
+  const typeMappings: TypeMapping = {
+    last_seen: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['PublishedTrackMetrics'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     warnings: { type: 'SessionWarningResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.PushNotificationFields = (input?: Record<string, any>) => {
+decoders['PushNotificationFields'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     providers: { type: 'PushProvider', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.PushNotificationSettingsResponse = (input?: Record<string, any>) => {
+decoders['PushNotificationSettingsResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     disabled_until: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.PushPreferencesResponse = (input?: Record<string, any>) => {
+decoders['PushPreferencesResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     disabled_until: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.PushProvider = (input?: Record<string, any>) => {
+decoders['PushProvider'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4156,7 +4288,7 @@ decoders.PushProvider = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.PushProviderResponse = (input?: Record<string, any>) => {
+decoders['PushProviderResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4167,7 +4299,7 @@ decoders.PushProviderResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.PushTemplate = (input?: Record<string, any>) => {
+decoders['PushTemplate'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4176,7 +4308,7 @@ decoders.PushTemplate = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.PushTemplateResponse = (input?: Record<string, any>) => {
+decoders['PushTemplateResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4185,65 +4317,67 @@ decoders.PushTemplateResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.QueryActivitiesResponse = (input?: Record<string, any>) => {
+decoders['QueryActivitiesResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     activities: { type: 'ActivityResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryActivityReactionsResponse = (input?: Record<string, any>) => {
+decoders['QueryActivityReactionsResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     reactions: { type: 'FeedsReactionResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryActivitySharesResponse = (input?: Record<string, any>) => {
+decoders['QueryActivitySharesResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     shares: { type: 'ShareResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryAppealsResponse = (input?: Record<string, any>) => {
+decoders['QueryAppealsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     items: { type: 'AppealItemResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryBannedUsersResponse = (input?: Record<string, any>) => {
+decoders['QueryBannedUsersResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     bans: { type: 'BanResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryBookmarkFoldersResponse = (input?: Record<string, any>) => {
+decoders['QueryBookmarkFoldersResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     bookmark_folders: { type: 'BookmarkFolderResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryBookmarksResponse = (input?: Record<string, any>) => {
+decoders['QueryBookmarksResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     bookmarks: { type: 'BookmarkResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryCallMembersResponse = (input?: Record<string, any>) => {
+decoders['QueryCallMembersResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     members: { type: 'MemberResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryCallParticipantSessionsResponse = (
-  input?: Record<string, any>,
-) => {
+decoders['QueryCallParticipantSessionsResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     participants_sessions: {
       type: 'ParticipantSessionDetails',
@@ -4255,7 +4389,9 @@ decoders.QueryCallParticipantSessionsResponse = (
   return decode(typeMappings, input);
 };
 
-decoders.QueryCallParticipantsResponse = (input?: Record<string, any>) => {
+decoders['QueryCallParticipantsResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     members: { type: 'MemberResponse', isSingle: false },
 
@@ -4266,9 +4402,9 @@ decoders.QueryCallParticipantsResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.QueryCallSessionParticipantStatsResponse = (
-  input?: Record<string, any>,
-) => {
+decoders['QueryCallSessionParticipantStatsResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     participants: { type: 'CallStatsParticipant', isSingle: false },
 
@@ -4279,23 +4415,25 @@ decoders.QueryCallSessionParticipantStatsResponse = (
   return decode(typeMappings, input);
 };
 
-decoders.QueryCallSessionParticipantStatsTimelineResponse = (
-  input?: Record<string, any>,
-) => {
+decoders['QueryCallSessionParticipantStatsTimelineResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     events: { type: 'CallParticipantTimeline', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryCallSessionStatsResponse = (input?: Record<string, any>) => {
+decoders['QueryCallSessionStatsResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     call_stats: { type: 'CallStatsSessionResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryCallStatsMapResponse = (input?: Record<string, any>) => {
+decoders['QueryCallStatsMapResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     call_ended_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4310,70 +4448,72 @@ decoders.QueryCallStatsMapResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.QueryCallStatsResponse = (input?: Record<string, any>) => {
+decoders['QueryCallStatsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     reports: { type: 'CallStatsReportSummaryResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryCallsResponse = (input?: Record<string, any>) => {
+decoders['QueryCallsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     calls: { type: 'CallStateResponseFields', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryCampaignsResponse = (input?: Record<string, any>) => {
+decoders['QueryCampaignsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     campaigns: { type: 'CampaignResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryChannelsResponse = (input?: Record<string, any>) => {
+decoders['QueryChannelsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     channels: { type: 'ChannelStateResponseFields', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryCollectionsResponse = (input?: Record<string, any>) => {
+decoders['QueryCollectionsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     collections: { type: 'CollectionResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryCommentReactionsResponse = (input?: Record<string, any>) => {
+decoders['QueryCommentReactionsResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     reactions: { type: 'FeedsReactionResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryCommentsResponse = (input?: Record<string, any>) => {
+decoders['QueryCommentsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     comments: { type: 'CommentResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryDraftsResponse = (input?: Record<string, any>) => {
+decoders['QueryDraftsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     drafts: { type: 'DraftResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryFeedMembersResponse = (input?: Record<string, any>) => {
+decoders['QueryFeedMembersResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     members: { type: 'FeedMemberResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryFeedModerationTemplate = (input?: Record<string, any>) => {
+decoders['QueryFeedModerationTemplate'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4382,170 +4522,187 @@ decoders.QueryFeedModerationTemplate = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.QueryFeedModerationTemplatesResponse = (
-  input?: Record<string, any>,
-) => {
+decoders['QueryFeedModerationTemplatesResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     templates: { type: 'QueryFeedModerationTemplate', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryFeedsResponse = (input?: Record<string, any>) => {
+decoders['QueryFeedsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     feeds: { type: 'FeedResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryFollowsResponse = (input?: Record<string, any>) => {
+decoders['QueryFollowsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     follows: { type: 'FollowResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryFutureChannelBansResponse = (input?: Record<string, any>) => {
+decoders['QueryFutureChannelBansResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     bans: { type: 'FutureChannelBanResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryLabelResultsResponse = (input?: Record<string, any>) => {
+decoders['QueryLabelResultsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     label_results: { type: 'LabelResultResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryMembershipLevelsResponse = (input?: Record<string, any>) => {
+decoders['QueryMembershipLevelsResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     membership_levels: { type: 'MembershipLevelResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryMessageFlagsResponse = (input?: Record<string, any>) => {
+decoders['QueryMessageFlagsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     flags: { type: 'MessageFlagResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryMessageHistoryResponse = (input?: Record<string, any>) => {
+decoders['QueryMessageHistoryResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     message_history: { type: 'MessageHistoryEntryResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryModerationConfigsResponse = (input?: Record<string, any>) => {
+decoders['QueryModerationConfigsResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     configs: { type: 'ConfigResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryModerationFlagsResponse = (input?: Record<string, any>) => {
+decoders['QueryModerationFlagsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     flags: { type: 'ModerationFlagResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryModerationLogsResponse = (input?: Record<string, any>) => {
+decoders['QueryModerationLogsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     logs: { type: 'ActionLogResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryModerationRulesResponse = (input?: Record<string, any>) => {
+decoders['QueryModerationRulesResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     rules: { type: 'ModerationRuleV2Response', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryPinnedActivitiesResponse = (input?: Record<string, any>) => {
+decoders['QueryPinnedActivitiesResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     pinned_activities: { type: 'ActivityPinResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryPollsResponse = (input?: Record<string, any>) => {
+decoders['QueryPollsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     polls: { type: 'PollResponseData', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryReactionsResponse = (input?: Record<string, any>) => {
+decoders['QueryPredefinedFiltersResponse'] = (input?: {
+  [key: string]: any;
+}) => {
+  const typeMappings: TypeMapping = {
+    predefined_filters: { type: 'PredefinedFilterResponse', isSingle: false },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['QueryReactionsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     reactions: { type: 'ReactionResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryRemindersResponse = (input?: Record<string, any>) => {
+decoders['QueryRemindersResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     reminders: { type: 'ReminderResponseData', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryReviewQueueResponse = (input?: Record<string, any>) => {
+decoders['QueryReviewQueueResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     items: { type: 'ReviewQueueItemResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryRevisionHistoryResponse = (input?: Record<string, any>) => {
+decoders['QueryRevisionHistoryResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     revisions: { type: 'RevisionHistoryResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QuerySegmentTargetsResponse = (input?: Record<string, any>) => {
+decoders['QuerySegmentTargetsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     targets: { type: 'SegmentTargetResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QuerySegmentsResponse = (input?: Record<string, any>) => {
+decoders['QuerySegmentsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     segments: { type: 'SegmentResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryThreadsResponse = (input?: Record<string, any>) => {
+decoders['QueryThreadsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     threads: { type: 'ThreadStateResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueryUsersResponse = (input?: Record<string, any>) => {
+decoders['QueryUsersResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     users: { type: 'FullUserResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.QueueResponse = (input?: Record<string, any>) => {
+decoders['QueueResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     queue: { type: 'ModerationQueueResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.Reaction = (input?: Record<string, any>) => {
+decoders['Reaction'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4556,7 +4713,7 @@ decoders.Reaction = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ReactionDeletedEvent = (input?: Record<string, any>) => {
+decoders['ReactionDeletedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4575,7 +4732,7 @@ decoders.ReactionDeletedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ReactionGroupResponse = (input?: Record<string, any>) => {
+decoders['ReactionGroupResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     first_reaction_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4586,7 +4743,7 @@ decoders.ReactionGroupResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ReactionGroupUserResponse = (input?: Record<string, any>) => {
+decoders['ReactionGroupUserResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4595,7 +4752,7 @@ decoders.ReactionGroupUserResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ReactionNewEvent = (input?: Record<string, any>) => {
+decoders['ReactionNewEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4614,7 +4771,7 @@ decoders.ReactionNewEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ReactionResponse = (input?: Record<string, any>) => {
+decoders['ReactionResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4625,7 +4782,7 @@ decoders.ReactionResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ReactionUpdatedEvent = (input?: Record<string, any>) => {
+decoders['ReactionUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4642,21 +4799,21 @@ decoders.ReactionUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ReactivateUserResponse = (input?: Record<string, any>) => {
+decoders['ReactivateUserResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     user: { type: 'UserResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ReadCollectionsResponse = (input?: Record<string, any>) => {
+decoders['ReadCollectionsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     collections: { type: 'CollectionResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ReadStateResponse = (input?: Record<string, any>) => {
+decoders['ReadStateResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     last_read: { type: 'DatetimeType', isSingle: true },
 
@@ -4667,21 +4824,23 @@ decoders.ReadStateResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.RejectFeedMemberInviteResponse = (input?: Record<string, any>) => {
+decoders['RejectFeedMemberInviteResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     member: { type: 'FeedMemberResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.RejectFollowResponse = (input?: Record<string, any>) => {
+decoders['RejectFollowResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     follow: { type: 'FollowResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ReminderCreatedEvent = (input?: Record<string, any>) => {
+decoders['ReminderCreatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4692,7 +4851,7 @@ decoders.ReminderCreatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ReminderDeletedEvent = (input?: Record<string, any>) => {
+decoders['ReminderDeletedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4703,7 +4862,7 @@ decoders.ReminderDeletedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ReminderNotificationEvent = (input?: Record<string, any>) => {
+decoders['ReminderNotificationEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4714,7 +4873,7 @@ decoders.ReminderNotificationEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ReminderResponseData = (input?: Record<string, any>) => {
+decoders['ReminderResponseData'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4731,7 +4890,7 @@ decoders.ReminderResponseData = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ReminderUpdatedEvent = (input?: Record<string, any>) => {
+decoders['ReminderUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4742,14 +4901,16 @@ decoders.ReminderUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.RemoveUserGroupMembersResponse = (input?: Record<string, any>) => {
+decoders['RemoveUserGroupMembersResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     user_group: { type: 'UserGroupResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ReportResponse = (input?: Record<string, any>) => {
+decoders['ReportResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     call: { type: 'CallReportResponse', isSingle: true },
 
@@ -4758,7 +4919,7 @@ decoders.ReportResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ResolveSipInboundResponse = (input?: Record<string, any>) => {
+decoders['ResolveSipInboundResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     sip_routing_rule: { type: 'SIPInboundRoutingRuleResponse', isSingle: true },
 
@@ -4767,14 +4928,14 @@ decoders.ResolveSipInboundResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.RestoreActivityResponse = (input?: Record<string, any>) => {
+decoders['RestoreActivityResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     activity: { type: 'ActivityResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.RestoreCommentResponse = (input?: Record<string, any>) => {
+decoders['RestoreCommentResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     activity: { type: 'ActivityResponse', isSingle: true },
 
@@ -4783,21 +4944,21 @@ decoders.RestoreCommentResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.RestoreFeedGroupResponse = (input?: Record<string, any>) => {
+decoders['RestoreFeedGroupResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     feed_group: { type: 'FeedGroupResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.RetentionPolicy = (input?: Record<string, any>) => {
+decoders['RetentionPolicy'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     enabled_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.ReviewQueueItemNewEvent = (input?: Record<string, any>) => {
+decoders['ReviewQueueItemNewEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4812,7 +4973,7 @@ decoders.ReviewQueueItemNewEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ReviewQueueItemResponse = (input?: Record<string, any>) => {
+decoders['ReviewQueueItemResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4851,7 +5012,7 @@ decoders.ReviewQueueItemResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ReviewQueueItemUpdatedEvent = (input?: Record<string, any>) => {
+decoders['ReviewQueueItemUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4866,23 +5027,14 @@ decoders.ReviewQueueItemUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.RevisionHistoryResponse = (input?: Record<string, any>) => {
+decoders['RevisionHistoryResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.Role = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    updated_at: { type: 'DatetimeType', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.SIPInboundRoutingRuleResponse = (input?: Record<string, any>) => {
+decoders['Role'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4891,7 +5043,9 @@ decoders.SIPInboundRoutingRuleResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.SIPTrunkResponse = (input?: Record<string, any>) => {
+decoders['SIPInboundRoutingRuleResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4900,21 +5054,30 @@ decoders.SIPTrunkResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.SearchResponse = (input?: Record<string, any>) => {
+decoders['SIPTrunkResponse'] = (input?: { [key: string]: any }) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    updated_at: { type: 'DatetimeType', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['SearchResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     results: { type: 'SearchResult', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.SearchResult = (input?: Record<string, any>) => {
+decoders['SearchResult'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     message: { type: 'SearchResultMessage', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.SearchResultMessage = (input?: Record<string, any>) => {
+decoders['SearchResultMessage'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4959,21 +5122,21 @@ decoders.SearchResultMessage = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.SearchRolesResponse = (input?: Record<string, any>) => {
+decoders['SearchRolesResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     roles: { type: 'Role', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.SearchUserGroupsResponse = (input?: Record<string, any>) => {
+decoders['SearchUserGroupsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     user_groups: { type: 'UserGroupResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.Segment = (input?: Record<string, any>) => {
+decoders['Segment'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4984,7 +5147,7 @@ decoders.Segment = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.SegmentResponse = (input?: Record<string, any>) => {
+decoders['SegmentResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -4995,14 +5158,14 @@ decoders.SegmentResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.SegmentTargetResponse = (input?: Record<string, any>) => {
+decoders['SegmentTargetResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.SendMessageResponse = (input?: Record<string, any>) => {
+decoders['SendMessageResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     message: { type: 'MessageResponse', isSingle: true },
 
@@ -5011,7 +5174,7 @@ decoders.SendMessageResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.SendReactionResponse = (input?: Record<string, any>) => {
+decoders['SendReactionResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     message: { type: 'MessageResponse', isSingle: true },
 
@@ -5020,21 +5183,21 @@ decoders.SendReactionResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.SessionWarningResponse = (input?: Record<string, any>) => {
+decoders['SessionWarningResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     time: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.SetRetentionPolicyResponse = (input?: Record<string, any>) => {
+decoders['SetRetentionPolicyResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     policy: { type: 'RetentionPolicy', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.SetupSession = (input?: Record<string, any>) => {
+decoders['SetupSession'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5045,7 +5208,7 @@ decoders.SetupSession = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ShareResponse = (input?: Record<string, any>) => {
+decoders['ShareResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5054,7 +5217,7 @@ decoders.ShareResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.SharedLocationResponse = (input?: Record<string, any>) => {
+decoders['SharedLocationResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5069,7 +5232,7 @@ decoders.SharedLocationResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.SharedLocationResponseData = (input?: Record<string, any>) => {
+decoders['SharedLocationResponseData'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5084,7 +5247,7 @@ decoders.SharedLocationResponseData = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.SharedLocationsResponse = (input?: Record<string, any>) => {
+decoders['SharedLocationsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     active_live_locations: {
       type: 'SharedLocationResponseData',
@@ -5094,28 +5257,28 @@ decoders.SharedLocationsResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.SingleFollowResponse = (input?: Record<string, any>) => {
+decoders['SingleFollowResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     follow: { type: 'FollowResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.StartCampaignResponse = (input?: Record<string, any>) => {
+decoders['StartCampaignResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     campaign: { type: 'CampaignResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.StopLiveResponse = (input?: Record<string, any>) => {
+decoders['StopLiveResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     call: { type: 'CallResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.StoriesFeedUpdatedEvent = (input?: Record<string, any>) => {
+decoders['StoriesFeedUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5133,7 +5296,7 @@ decoders.StoriesFeedUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.SubmitActionResponse = (input?: Record<string, any>) => {
+decoders['SubmitActionResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     appeal_item: { type: 'AppealItemResponse', isSingle: true },
 
@@ -5142,7 +5305,7 @@ decoders.SubmitActionResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ThreadParticipant = (input?: Record<string, any>) => {
+decoders['ThreadParticipant'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5157,7 +5320,7 @@ decoders.ThreadParticipant = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ThreadResponse = (input?: Record<string, any>) => {
+decoders['ThreadResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5178,7 +5341,7 @@ decoders.ThreadResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ThreadStateResponse = (input?: Record<string, any>) => {
+decoders['ThreadStateResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5205,7 +5368,7 @@ decoders.ThreadStateResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ThreadUpdatedEvent = (input?: Record<string, any>) => {
+decoders['ThreadUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5216,7 +5379,7 @@ decoders.ThreadUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.ThreadedCommentResponse = (input?: Record<string, any>) => {
+decoders['ThreadedCommentResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5241,21 +5404,21 @@ decoders.ThreadedCommentResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.TranslateActivityResponse = (input?: Record<string, any>) => {
+decoders['TranslateActivityResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     activity: { type: 'ActivityResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.TranslateCommentResponse = (input?: Record<string, any>) => {
+decoders['TranslateCommentResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     comment: { type: 'CommentResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.TruncateChannelResponse = (input?: Record<string, any>) => {
+decoders['TruncateChannelResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     channel: { type: 'ChannelResponse', isSingle: true },
 
@@ -5264,7 +5427,7 @@ decoders.TruncateChannelResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UnblockedUserEvent = (input?: Record<string, any>) => {
+decoders['UnblockedUserEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5273,49 +5436,49 @@ decoders.UnblockedUserEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UndeleteMessageResponse = (input?: Record<string, any>) => {
+decoders['UndeleteMessageResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     message: { type: 'MessageResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UnfollowBatchResponse = (input?: Record<string, any>) => {
+decoders['UnfollowBatchResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     follows: { type: 'FollowResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UnfollowResponse = (input?: Record<string, any>) => {
+decoders['UnfollowResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     follow: { type: 'FollowResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UnpinActivityResponse = (input?: Record<string, any>) => {
+decoders['UnpinActivityResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     activity: { type: 'ActivityResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UnreadCountsBatchResponse = (input?: Record<string, any>) => {
+decoders['UnreadCountsBatchResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     counts_by_user: { type: 'UnreadCountsResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UnreadCountsChannel = (input?: Record<string, any>) => {
+decoders['UnreadCountsChannel'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     last_read: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UnreadCountsResponse = (input?: Record<string, any>) => {
+decoders['UnreadCountsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     channels: { type: 'UnreadCountsChannel', isSingle: false },
 
@@ -5324,65 +5487,67 @@ decoders.UnreadCountsResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UnreadCountsThread = (input?: Record<string, any>) => {
+decoders['UnreadCountsThread'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     last_read: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateActivitiesPartialBatchResponse = (
-  input?: Record<string, any>,
-) => {
+decoders['UpdateActivitiesPartialBatchResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     activities: { type: 'ActivityResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateActivityPartialResponse = (input?: Record<string, any>) => {
+decoders['UpdateActivityPartialResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     activity: { type: 'ActivityResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateActivityResponse = (input?: Record<string, any>) => {
+decoders['UpdateActivityResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     activity: { type: 'ActivityResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateBlockListResponse = (input?: Record<string, any>) => {
+decoders['UpdateBlockListResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     blocklist: { type: 'BlockListResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateBookmarkFolderResponse = (input?: Record<string, any>) => {
+decoders['UpdateBookmarkFolderResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     bookmark_folder: { type: 'BookmarkFolderResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateBookmarkResponse = (input?: Record<string, any>) => {
+decoders['UpdateBookmarkResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     bookmark: { type: 'BookmarkResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateCallMembersResponse = (input?: Record<string, any>) => {
+decoders['UpdateCallMembersResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     members: { type: 'MemberResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateCallResponse = (input?: Record<string, any>) => {
+decoders['UpdateCallResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     members: { type: 'MemberResponse', isSingle: false },
 
@@ -5391,7 +5556,7 @@ decoders.UpdateCallResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UpdateCallTypeResponse = (input?: Record<string, any>) => {
+decoders['UpdateCallTypeResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5400,7 +5565,7 @@ decoders.UpdateCallTypeResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UpdateChannelPartialResponse = (input?: Record<string, any>) => {
+decoders['UpdateChannelPartialResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     members: { type: 'ChannelMemberResponse', isSingle: false },
 
@@ -5409,7 +5574,7 @@ decoders.UpdateChannelPartialResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UpdateChannelResponse = (input?: Record<string, any>) => {
+decoders['UpdateChannelResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     members: { type: 'ChannelMemberResponse', isSingle: false },
 
@@ -5420,7 +5585,7 @@ decoders.UpdateChannelResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UpdateChannelTypeResponse = (input?: Record<string, any>) => {
+decoders['UpdateChannelTypeResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5429,49 +5594,51 @@ decoders.UpdateChannelTypeResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UpdateCollectionsResponse = (input?: Record<string, any>) => {
+decoders['UpdateCollectionsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     collections: { type: 'CollectionResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateCommandResponse = (input?: Record<string, any>) => {
+decoders['UpdateCommandResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     command: { type: 'Command', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateCommentBookmarkResponse = (input?: Record<string, any>) => {
+decoders['UpdateCommentBookmarkResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     bookmark: { type: 'BookmarkResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateCommentPartialResponse = (input?: Record<string, any>) => {
+decoders['UpdateCommentPartialResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     comment: { type: 'CommentResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateCommentResponse = (input?: Record<string, any>) => {
+decoders['UpdateCommentResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     comment: { type: 'CommentResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateFeedGroupResponse = (input?: Record<string, any>) => {
+decoders['UpdateFeedGroupResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     feed_group: { type: 'FeedGroupResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateFeedMembersResponse = (input?: Record<string, any>) => {
+decoders['UpdateFeedMembersResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     added: { type: 'FeedMemberResponse', isSingle: false },
 
@@ -5480,65 +5647,76 @@ decoders.UpdateFeedMembersResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UpdateFeedResponse = (input?: Record<string, any>) => {
+decoders['UpdateFeedResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     feed: { type: 'FeedResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateFeedViewResponse = (input?: Record<string, any>) => {
+decoders['UpdateFeedViewResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     feed_view: { type: 'FeedViewResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateFollowResponse = (input?: Record<string, any>) => {
+decoders['UpdateFollowResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     follow: { type: 'FollowResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateMemberPartialResponse = (input?: Record<string, any>) => {
+decoders['UpdateMemberPartialResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     channel_member: { type: 'ChannelMemberResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateMembershipLevelResponse = (input?: Record<string, any>) => {
+decoders['UpdateMembershipLevelResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     membership_level: { type: 'MembershipLevelResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateMessagePartialResponse = (input?: Record<string, any>) => {
+decoders['UpdateMessagePartialResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     message: { type: 'MessageResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateMessageResponse = (input?: Record<string, any>) => {
+decoders['UpdateMessageResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     message: { type: 'MessageResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateReminderResponse = (input?: Record<string, any>) => {
+decoders['UpdatePredefinedFilterResponse'] = (input?: {
+  [key: string]: any;
+}) => {
+  const typeMappings: TypeMapping = {
+    predefined_filter: { type: 'PredefinedFilterResponse', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['UpdateReminderResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     reminder: { type: 'ReminderResponseData', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateSIPInboundRoutingRuleResponse = (
-  input?: Record<string, any>,
-) => {
+decoders['UpdateSIPInboundRoutingRuleResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     sip_inbound_routing_rule: {
       type: 'SIPInboundRoutingRuleResponse',
@@ -5548,42 +5726,42 @@ decoders.UpdateSIPInboundRoutingRuleResponse = (
   return decode(typeMappings, input);
 };
 
-decoders.UpdateSIPTrunkResponse = (input?: Record<string, any>) => {
+decoders['UpdateSIPTrunkResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     sip_trunk: { type: 'SIPTrunkResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateSegmentResponse = (input?: Record<string, any>) => {
+decoders['UpdateSegmentResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     segment: { type: 'SegmentResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateThreadPartialResponse = (input?: Record<string, any>) => {
+decoders['UpdateThreadPartialResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     thread: { type: 'ThreadResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateUserGroupResponse = (input?: Record<string, any>) => {
+decoders['UpdateUserGroupResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     user_group: { type: 'UserGroupResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdateUsersResponse = (input?: Record<string, any>) => {
+decoders['UpdateUsersResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     users: { type: 'FullUserResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpdatedCallPermissionsEvent = (input?: Record<string, any>) => {
+decoders['UpdatedCallPermissionsEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5592,35 +5770,37 @@ decoders.UpdatedCallPermissionsEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UpsertActivitiesResponse = (input?: Record<string, any>) => {
+decoders['UpsertActivitiesResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     activities: { type: 'ActivityResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpsertCollectionsResponse = (input?: Record<string, any>) => {
+decoders['UpsertCollectionsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     collections: { type: 'CollectionResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpsertConfigResponse = (input?: Record<string, any>) => {
+decoders['UpsertConfigResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     config: { type: 'ConfigResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpsertModerationRuleResponse = (input?: Record<string, any>) => {
+decoders['UpsertModerationRuleResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     rule: { type: 'ModerationRuleV2Response', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpsertModerationTemplateResponse = (input?: Record<string, any>) => {
+decoders['UpsertModerationTemplateResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5629,35 +5809,37 @@ decoders.UpsertModerationTemplateResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UpsertPushPreferencesResponse = (input?: Record<string, any>) => {
+decoders['UpsertPushPreferencesResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     user_preferences: { type: 'PushPreferencesResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpsertPushProviderResponse = (input?: Record<string, any>) => {
+decoders['UpsertPushProviderResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     push_provider: { type: 'PushProviderResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpsertPushTemplateResponse = (input?: Record<string, any>) => {
+decoders['UpsertPushTemplateResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     template: { type: 'PushTemplateResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UpsertSetupSessionResponse = (input?: Record<string, any>) => {
+decoders['UpsertSetupSessionResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     setup_session: { type: 'SetupSession', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UserBannedEvent = (input?: Record<string, any>) => {
+decoders['UserBannedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5672,7 +5854,7 @@ decoders.UserBannedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UserDeactivatedEvent = (input?: Record<string, any>) => {
+decoders['UserDeactivatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5685,7 +5867,7 @@ decoders.UserDeactivatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UserDeletedEvent = (input?: Record<string, any>) => {
+decoders['UserDeletedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5696,7 +5878,7 @@ decoders.UserDeletedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UserFlaggedEvent = (input?: Record<string, any>) => {
+decoders['UserFlaggedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5709,7 +5891,7 @@ decoders.UserFlaggedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UserGroupCreatedEvent = (input?: Record<string, any>) => {
+decoders['UserGroupCreatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5720,7 +5902,7 @@ decoders.UserGroupCreatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UserGroupDeletedEvent = (input?: Record<string, any>) => {
+decoders['UserGroupDeletedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5731,25 +5913,14 @@ decoders.UserGroupDeletedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UserGroupMember = (input?: Record<string, any>) => {
+decoders['UserGroupMember'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.UserGroupMemberAddedEvent = (input?: Record<string, any>) => {
-  const typeMappings: TypeMapping = {
-    created_at: { type: 'DatetimeType', isSingle: true },
-
-    received_at: { type: 'DatetimeType', isSingle: true },
-
-    user: { type: 'UserResponseCommonFields', isSingle: true },
-  };
-  return decode(typeMappings, input);
-};
-
-decoders.UserGroupMemberRemovedEvent = (input?: Record<string, any>) => {
+decoders['UserGroupMemberAddedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5760,7 +5931,18 @@ decoders.UserGroupMemberRemovedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UserGroupResponse = (input?: Record<string, any>) => {
+decoders['UserGroupMemberRemovedEvent'] = (input?: { [key: string]: any }) => {
+  const typeMappings: TypeMapping = {
+    created_at: { type: 'DatetimeType', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
+
+    user: { type: 'UserResponseCommonFields', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
+decoders['UserGroupResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5771,7 +5953,7 @@ decoders.UserGroupResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UserGroupUpdatedEvent = (input?: Record<string, any>) => {
+decoders['UserGroupUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5782,7 +5964,7 @@ decoders.UserGroupUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UserMessagesDeletedEvent = (input?: Record<string, any>) => {
+decoders['UserMessagesDeletedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5793,7 +5975,7 @@ decoders.UserMessagesDeletedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UserMuteResponse = (input?: Record<string, any>) => {
+decoders['UserMuteResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5808,7 +5990,7 @@ decoders.UserMuteResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UserMutedEvent = (input?: Record<string, any>) => {
+decoders['UserMutedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5823,7 +6005,7 @@ decoders.UserMutedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UserReactivatedEvent = (input?: Record<string, any>) => {
+decoders['UserReactivatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5836,7 +6018,7 @@ decoders.UserReactivatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UserResponse = (input?: Record<string, any>) => {
+decoders['UserResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5862,7 +6044,7 @@ decoders.UserResponse = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UserResponseCommonFields = (input?: Record<string, any>) => {
+decoders['UserResponseCommonFields'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5879,7 +6061,7 @@ decoders.UserResponseCommonFields = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UserUnbannedEvent = (input?: Record<string, any>) => {
+decoders['UserUnbannedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5892,7 +6074,7 @@ decoders.UserUnbannedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UserUnmutedEvent = (input?: Record<string, any>) => {
+decoders['UserUnmutedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5907,7 +6089,7 @@ decoders.UserUnmutedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UserUnreadReminderEvent = (input?: Record<string, any>) => {
+decoders['UserUnreadReminderEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5918,7 +6100,7 @@ decoders.UserUnreadReminderEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.UserUpdatedEvent = (input?: Record<string, any>) => {
+decoders['UserUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5927,21 +6109,23 @@ decoders.UserUpdatedEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.VideoReactionOverTimeResponse = (input?: Record<string, any>) => {
+decoders['VideoReactionOverTimeResponse'] = (input?: {
+  [key: string]: any;
+}) => {
   const typeMappings: TypeMapping = {
     by_minute: { type: 'CountByMinuteResponse', isSingle: false },
   };
   return decode(typeMappings, input);
 };
 
-decoders.VideoReactionsResponse = (input?: Record<string, any>) => {
+decoders['VideoReactionsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     count_over_time: { type: 'VideoReactionOverTimeResponse', isSingle: true },
   };
   return decode(typeMappings, input);
 };
 
-decoders.WSEvent = (input?: Record<string, any>) => {
+decoders['WSEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
@@ -5970,7 +6154,7 @@ decoders.WSEvent = (input?: Record<string, any>) => {
   return decode(typeMappings, input);
 };
 
-decoders.WrappedUnreadCountsResponse = (input?: Record<string, any>) => {
+decoders['WrappedUnreadCountsResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     channels: { type: 'UnreadCountsChannel', isSingle: false },
 

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -1,7 +1,7 @@
 export interface AIAudioConfigRequest {
   profile?: string;
 
-  rules?: BodyguardRule[];
+  rules?: Array<BodyguardRule>;
 }
 
 export interface AIAudioConfigResponse {
@@ -9,7 +9,7 @@ export interface AIAudioConfigResponse {
 
   profile: string;
 
-  rules: BodyguardRule[];
+  rules: Array<BodyguardRule>;
 }
 
 export interface AIImageConfig {
@@ -17,9 +17,9 @@ export interface AIImageConfig {
 
   enabled?: boolean;
 
-  ocr_rules?: OCRRule[];
+  ocr_rules?: Array<OCRRule>;
 
-  rules?: AWSRekognitionRule[];
+  rules?: Array<AWSRekognitionRule>;
 }
 
 export interface AIImageLabelDefinition {
@@ -39,9 +39,9 @@ export interface AITextConfig {
 
   profile?: string;
 
-  rules?: BodyguardRule[];
+  rules?: Array<BodyguardRule>;
 
-  severity_rules?: BodyguardSeverityRule[];
+  severity_rules?: Array<BodyguardSeverityRule>;
 }
 
 export interface AIVideoConfig {
@@ -49,7 +49,7 @@ export interface AIVideoConfig {
 
   enabled?: boolean;
 
-  rules?: AWSRekognitionRule[];
+  rules?: Array<AWSRekognitionRule>;
 }
 
 export interface APIError {
@@ -81,7 +81,7 @@ export interface APIError {
   /**
    * Additional error-specific information
    */
-  details: number[];
+  details: Array<number>;
 
   /**
    * Flag that indicates if the error is unrecoverable, requests that return unrecoverable errors should not be retried, this error only applies to the request that caused it
@@ -269,7 +269,7 @@ export interface ActionLogResponse {
    */
   user_id: string;
 
-  ai_providers: string[];
+  ai_providers: Array<string>;
 
   /**
    * Additional metadata about the action
@@ -524,17 +524,17 @@ export interface ActivityMarkEvent {
   /**
    * The IDs of activities marked as read
    */
-  mark_read?: string[];
+  mark_read?: Array<string>;
 
   /**
    * The IDs of activities marked as seen
    */
-  mark_seen?: string[];
+  mark_seen?: Array<string>;
 
   /**
    * The IDs of activities marked as watched
    */
-  mark_watched?: string[];
+  mark_watched?: Array<string>;
 
   user?: UserResponseCommonFields;
 }
@@ -708,7 +708,7 @@ export interface ActivityRequest {
   /**
    * List of feeds to add the activity to with a default max limit of 25 feeds
    */
-  feeds: string[];
+  feeds: Array<string>;
 
   /**
    * @deprecated
@@ -781,32 +781,32 @@ export interface ActivityRequest {
   /**
    * List of attachments for the activity
    */
-  attachments?: Attachment[];
+  attachments?: Array<Attachment>;
 
   /**
    * Collections that this activity references
    */
-  collection_refs?: string[];
+  collection_refs?: Array<string>;
 
   /**
    * Collections to create or update as part of this request, so an activity and the collections it references can be written in one call. Their refs (name:id) are added to collection_refs automatically; you do not need to restate them, and they count toward the same per-activity collection-reference limit, which is the effective cap here. A collection that already exists has its custom data updated. Use collection_refs instead when the collection already exists and you are only referencing it, which requires no collection permissions.
    */
-  collections?: CollectionRequest[];
+  collections?: Array<CollectionRequest>;
 
   /**
    * Tags for filtering activities
    */
-  filter_tags?: string[];
+  filter_tags?: Array<string>;
 
   /**
    * Tags for indicating user interests
    */
-  interest_tags?: string[];
+  interest_tags?: Array<string>;
 
   /**
    * List of users mentioned in the activity
    */
-  mentioned_user_ids?: string[];
+  mentioned_user_ids?: Array<string>;
 
   /**
    * Custom data for the activity
@@ -897,47 +897,47 @@ export interface ActivityResponse {
   /**
    * Media attachments for the activity
    */
-  attachments: Attachment[];
+  attachments: Array<Attachment>;
 
   /**
    * Latest 5 comments of this activity (comment replies excluded)
    */
-  comments: CommentResponse[];
+  comments: Array<CommentResponse>;
 
   /**
    * List of feed IDs containing this activity
    */
-  feeds: string[];
+  feeds: Array<string>;
 
   /**
    * Tags for filtering
    */
-  filter_tags: string[];
+  filter_tags: Array<string>;
 
   /**
    * Tags for user interests
    */
-  interest_tags: string[];
+  interest_tags: Array<string>;
 
   /**
    * Recent reactions to the activity
    */
-  latest_reactions: FeedsReactionResponse[];
+  latest_reactions: Array<FeedsReactionResponse>;
 
   /**
    * Users mentioned in the activity
    */
-  mentioned_users: UserResponse[];
+  mentioned_users: Array<UserResponse>;
 
   /**
    * Current user's bookmarks for this activity
    */
-  own_bookmarks: BookmarkResponse[];
+  own_bookmarks: Array<BookmarkResponse>;
 
   /**
    * Current user's reactions to this activity
    */
-  own_reactions: FeedsReactionResponse[];
+  own_reactions: Array<FeedsReactionResponse>;
 
   /**
    * Enriched collection data referenced by this activity
@@ -1016,12 +1016,12 @@ export interface ActivityResponse {
   /**
    * Reactions from users the current user follows or has mutual follows with
    */
-  friend_reactions?: FeedsReactionResponse[];
+  friend_reactions?: Array<FeedsReactionResponse>;
 
   /**
    * Recent shares of the activity, one entry per share (org-gated)
    */
-  latest_shares?: ShareResponse[];
+  latest_shares?: Array<ShareResponse>;
 
   current_feed?: FeedResponse;
 
@@ -1101,7 +1101,7 @@ export interface ActivitySelectorConfig {
   /**
    * Sort parameters for activity selection
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter for activity selection
@@ -1143,7 +1143,7 @@ export interface ActivitySelectorConfigResponse {
   /**
    * Sort parameters for activity selection
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter for activity selection
@@ -1216,7 +1216,7 @@ export interface AddActivityRequest {
   /**
    * List of feeds to add the activity to with a default max limit of 25 feeds
    */
-  feeds: string[];
+  feeds: Array<string>;
 
   /**
    * @deprecated
@@ -1295,32 +1295,32 @@ export interface AddActivityRequest {
   /**
    * List of attachments for the activity
    */
-  attachments?: Attachment[];
+  attachments?: Array<Attachment>;
 
   /**
    * Collections that this activity references
    */
-  collection_refs?: string[];
+  collection_refs?: Array<string>;
 
   /**
    * Collections to create or update as part of this request, so an activity and the collections it references can be written in one call. Their refs (name:id) are added to collection_refs automatically; you do not need to restate them, and they count toward the same per-activity collection-reference limit, which is the effective cap here. A collection that already exists has its custom data updated. Use collection_refs instead when the collection already exists and you are only referencing it, which requires no collection permissions.
    */
-  collections?: CollectionRequest[];
+  collections?: Array<CollectionRequest>;
 
   /**
    * Tags for filtering activities
    */
-  filter_tags?: string[];
+  filter_tags?: Array<string>;
 
   /**
    * Tags for indicating user interests
    */
-  interest_tags?: string[];
+  interest_tags?: Array<string>;
 
   /**
    * List of users mentioned in the activity
    */
-  mentioned_user_ids?: string[];
+  mentioned_user_ids?: Array<string>;
 
   /**
    * Custom data for the activity
@@ -1429,7 +1429,7 @@ export interface AddCommentReactionRequest {
   /**
    * Optional list of feeds to create a reference (share) activity of the commented-on activity in. The reference activity's type mirrors the reaction type.
    */
-  target_feeds?: string[];
+  target_feeds?: Array<string>;
 
   /**
    * Optional custom data to add to the reaction
@@ -1525,12 +1525,12 @@ export interface AddCommentRequest {
   /**
    * Media attachments for the reply
    */
-  attachments?: Attachment[];
+  attachments?: Array<Attachment>;
 
   /**
    * List of users mentioned in the reply
    */
-  mentioned_user_ids?: string[];
+  mentioned_user_ids?: Array<string>;
 
   /**
    * Custom data for the comment
@@ -1563,7 +1563,7 @@ export interface AddCommentsBatchRequest {
   /**
    * List of comments to add
    */
-  comments: AddCommentRequest[];
+  comments: Array<AddCommentRequest>;
 }
 
 export interface AddCommentsBatchResponse {
@@ -1572,7 +1572,7 @@ export interface AddCommentsBatchResponse {
   /**
    * List of comments added
    */
-  comments: CommentResponse[];
+  comments: Array<CommentResponse>;
 }
 
 export interface AddFolderRequest {
@@ -1621,7 +1621,7 @@ export interface AddReactionRequest {
   /**
    * Optional list of feeds to create a reference (share) activity of the original activity in. The reference activity's type mirrors the reaction type.
    */
-  target_feeds?: string[];
+  target_feeds?: Array<string>;
 
   /**
    * Custom data for the reaction
@@ -1664,14 +1664,14 @@ export interface AddSegmentTargetsRequest {
   /**
    * Target IDs
    */
-  target_ids: string[];
+  target_ids: Array<string>;
 }
 
 export interface AddUserGroupMembersRequest {
   /**
    * List of user IDs to add as members
    */
-  member_ids: string[];
+  member_ids: Array<string>;
 
   /**
    * Whether to add the members as group admins. Defaults to false
@@ -1726,7 +1726,7 @@ export interface AggregatedActivityResponse {
   /**
    * List of activities in this aggregation
    */
-  activities: ActivityResponse[];
+  activities: Array<ActivityResponse>;
 
   /**
    * Whether this aggregated group has been read. Only set for feed groups with notification config (track_seen/track_read enabled).
@@ -1784,12 +1784,12 @@ export interface AnalyzeImageField {
   /**
    * Hierarchical list of L1 (parent) classifications. Each entry: `name`, `confidence` (0–1), and nested `subclassifications` (L2 leaves with their own confidence). Resolved against the app's effective taxonomy (custom taxonomy when configured, otherwise the standard Bodyguard catalogue).
    */
-  classifications?: Classification[];
+  classifications?: Array<Classification>;
 
   /**
    * Flat list of Bodyguard OCR text-moderation labels on the image's extracted text (e.g. VULGARITY, PII). Each entry: `name` + `severity`. Populated when BG's OCR pipeline returned non-empty results for this image.
    */
-  ocr_classifications?: Classification[];
+  ocr_classifications?: Array<Classification>;
 }
 
 export interface AnalyzeRequest {
@@ -1894,7 +1894,7 @@ export interface AnalyzeTextField {
   /**
    * Flat list of detected Bodyguard text labels (e.g. INSULT, VULGARITY). Each entry carries `name` and `severity`.
    */
-  classifications?: Classification[];
+  classifications?: Array<Classification>;
 }
 
 export interface AppResponseFields {
@@ -1974,11 +1974,11 @@ export interface AppResponseFields {
 
   webhook_url: string;
 
-  event_hooks: EventHook[];
+  event_hooks: Array<EventHook>;
 
-  user_search_disallowed_roles: string[];
+  user_search_disallowed_roles: Array<string>;
 
-  webhook_events: string[];
+  webhook_events: Array<string>;
 
   call_types: Record<string, CallType>;
 
@@ -1986,11 +1986,11 @@ export interface AppResponseFields {
 
   file_upload_config: FileUploadConfig;
 
-  grants: Record<string, string[]>;
+  grants: Record<string, Array<string>>;
 
   image_upload_config: FileUploadConfig;
 
-  policies: Record<string, Policy[]>;
+  policies: Record<string, Array<Policy>>;
 
   push_notifications: PushNotificationFields;
 
@@ -2008,11 +2008,11 @@ export interface AppResponseFields {
 
   video_primary_use_case?: string;
 
-  allowed_flag_reasons?: string[];
+  allowed_flag_reasons?: Array<string>;
 
-  geofences?: GeofenceResponse[];
+  geofences?: Array<GeofenceResponse>;
 
-  image_moderation_labels?: string[];
+  image_moderation_labels?: Array<string>;
 
   activity_metrics_config?: Record<string, number>;
 
@@ -2116,27 +2116,27 @@ export interface AppealItemResponse {
   /**
    * Full chronological history of all moderation actions on the review queue item
    */
-  actions?: ActionLogResponse[];
+  actions?: Array<ActionLogResponse>;
 
   /**
    * Attachments(e.g. Images) of the Appeal Item
    */
-  attachments?: string[];
+  attachments?: Array<string>;
 
   /**
    * Classification labels from automated and manual review
    */
-  flag_labels?: string[];
+  flag_labels?: Array<string>;
 
   /**
    * Types of flags applied to the entity (e.g. user_report, bodyguard)
    */
-  flag_types?: string[];
+  flag_types?: Array<string>;
 
   /**
    * Per-provider flag records explaining why the action was taken
    */
-  flags?: ModerationFlagResponse[];
+  flags?: Array<ModerationFlagResponse>;
 
   entity_content?: ModerationPayload;
 
@@ -2188,7 +2188,7 @@ export interface AppealRequest {
   /**
    * Array of Attachment URLs(e.g., images)
    */
-  attachments?: string[];
+  attachments?: Array<string>;
 
   /**
    * User request object
@@ -2367,9 +2367,9 @@ export interface Attachment {
    */
   type?: string;
 
-  actions?: Action[];
+  actions?: Array<Action>;
 
-  fields?: Field[];
+  fields?: Array<Field>;
 
   giphy?: Images;
 }
@@ -2385,7 +2385,7 @@ export interface Audience {
 
   viewer_connections: number;
 
-  concurrency_by_minute: ConcurrencyMinute[];
+  concurrency_by_minute: Array<ConcurrencyMinute>;
 
   peak_at?: string;
 
@@ -2457,7 +2457,7 @@ export interface AutomodDetailsResponse {
 
   original_message_type?: string;
 
-  image_labels?: string[];
+  image_labels?: Array<string>;
 
   message_details?: FlagMessageDetailsResponse;
 
@@ -2472,7 +2472,7 @@ export interface AutomodPlatformCircumventionConfig {
 
   enabled?: boolean;
 
-  rules?: AutomodRule[];
+  rules?: Array<AutomodRule>;
 }
 
 export interface AutomodRule {
@@ -2489,7 +2489,7 @@ export interface AutomodSemanticFiltersConfig {
 
   enabled?: boolean;
 
-  rules?: AutomodSemanticFiltersRule[];
+  rules?: Array<AutomodSemanticFiltersRule>;
 }
 
 export interface AutomodSemanticFiltersRule {
@@ -2506,7 +2506,7 @@ export interface AutomodToxicityConfig {
 
   enabled?: boolean;
 
-  rules?: AutomodRule[];
+  rules?: Array<AutomodRule>;
 }
 
 export interface AzureRequest {
@@ -2718,7 +2718,7 @@ export interface BatchQueryActivityReactionsRequest {
   /**
    * Activity IDs to fetch the user's reactions for (max 100)
    */
-  activity_ids: string[];
+  activity_ids: Array<string>;
 
   limit?: number;
 
@@ -2731,7 +2731,7 @@ export interface BatchQueryActivityReactionsRequest {
    */
   user_id?: string;
 
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Optional filter on reaction_type or created_at
@@ -2750,7 +2750,7 @@ export interface BatchQueryActivityReactionsResponse {
    */
   duration: string;
 
-  reactions: FeedsReactionResponse[];
+  reactions: Array<FeedsReactionResponse>;
 
   next?: string;
 
@@ -2761,7 +2761,7 @@ export interface BatchQueryCommentReactionsRequest {
   /**
    * Comment IDs to fetch the user's reactions for (max 100)
    */
-  comment_ids: string[];
+  comment_ids: Array<string>;
 
   limit?: number;
 
@@ -2774,7 +2774,7 @@ export interface BatchQueryCommentReactionsRequest {
    */
   user_id?: string;
 
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Optional filter on reaction_type or created_at
@@ -2793,7 +2793,7 @@ export interface BatchQueryCommentReactionsResponse {
    */
   duration: string;
 
-  reactions: FeedsReactionResponse[];
+  reactions: Array<FeedsReactionResponse>;
 
   next?: string;
 
@@ -2814,7 +2814,7 @@ export interface BlockListConfig {
 
   match_substring?: boolean;
 
-  rules?: BlockListRule[];
+  rules?: Array<BlockListRule>;
 }
 
 export interface BlockListOptions {
@@ -2852,7 +2852,7 @@ export interface BlockListResponse {
   /**
    * List of words to block
    */
-  words: string[];
+  words: Array<string>;
 
   /**
    * Date/time of creation
@@ -2983,7 +2983,7 @@ export interface BlockedUserResponse {
 }
 
 export interface BodyguardImageAnalysisConfig {
-  rules?: BodyguardRule[];
+  rules?: Array<BodyguardRule>;
 }
 
 export interface BodyguardProfileSummary {
@@ -3008,7 +3008,7 @@ export interface BodyguardRule {
     | 'bounce_flag'
     | 'bounce_remove';
 
-  severity_rules?: BodyguardSeverityRule[];
+  severity_rules?: Array<BodyguardSeverityRule>;
 }
 
 export interface BodyguardSeverityRule {
@@ -3224,7 +3224,7 @@ export interface BroadcastDailyRollup {
 
   unique_viewers_sum: number;
 
-  top_broadcasts: TopBroadcast[];
+  top_broadcasts: Array<TopBroadcast>;
 
   poor_viewers_by_cause: PoorByCause;
 }
@@ -3266,7 +3266,7 @@ export interface BroadcastInfo {
 
   started_at: string;
 
-  creators: string[];
+  creators: Array<string>;
 
   source_mode?: string;
 }
@@ -3334,7 +3334,7 @@ export interface BulkActionAppealsRequest {
   /**
    * List of appeal UUIDs to process
    */
-  appeal_ids: string[];
+  appeal_ids: Array<string>;
 
   user_id?: string;
 
@@ -3349,7 +3349,7 @@ export interface BulkActionAppealsRequest {
   reject_appeal?: RejectAppealRequestPayload;
 
   /**
-   * Configuration for restore action
+   * Configuration for restore action. State-aware: reverses whichever of a delete, a block, or a shadow block currently applies to the content (including both a delete and a block/shadow block at once).
    */
   restore?: RestoreActionRequestPayload;
 
@@ -3359,7 +3359,7 @@ export interface BulkActionAppealsRequest {
   unban?: UnbanActionRequestPayload;
 
   /**
-   * Configuration for unblock action
+   * Deprecated: use restore instead — it now also reverses a block or shadow block. Configuration for unblock action.
    */
   unblock?: UnblockActionRequestPayload;
 
@@ -3375,12 +3375,12 @@ export interface BulkActionAppealsResponse {
   /**
    * Appeals that could not be processed, with per-item error messages
    */
-  errors: BulkAppealError[];
+  errors: Array<BulkAppealError>;
 
   /**
    * Successfully processed appeals
    */
-  results: BulkAppealResult[];
+  results: Array<BulkAppealResult>;
 }
 
 export interface BulkAppealError {
@@ -3399,7 +3399,7 @@ export interface BulkDeleteActionConfigRequest {
   /**
    * UUIDs of the action configs to delete
    */
-  ids: string[];
+  ids: Array<string>;
 
   user_id?: string;
 
@@ -3438,7 +3438,7 @@ export interface BulkUpsertActionConfigRequest {
   /**
    * List of action configs to create or update
    */
-  action_configs: UpsertActionConfigItem[];
+  action_configs: Array<UpsertActionConfigItem>;
 
   user_id?: string;
 
@@ -3454,7 +3454,7 @@ export interface BulkUpsertActionConfigResponse {
   /**
    * The created or updated action configs in the same order as the request
    */
-  action_configs: ModerationActionConfigResponse[];
+  action_configs: Array<ModerationActionConfigResponse>;
 }
 
 export interface BypassActionRequest {
@@ -3578,7 +3578,7 @@ export interface CallCreatedEvent {
   /**
    * the members added to this call
    */
-  members: MemberResponse[];
+  members: Array<MemberResponse>;
 
   /**
    * Represents a call
@@ -3650,11 +3650,11 @@ export interface CallDeletedEvent {
 }
 
 export interface CallDurationReport {
-  histogram: ReportByHistogramBucket[];
+  histogram: Array<ReportByHistogramBucket>;
 }
 
 export interface CallDurationReportResponse {
-  daily: DailyAggregateCallDurationReportResponse[];
+  daily: Array<DailyAggregateCallDurationReportResponse>;
 }
 
 export interface CallEndedEvent {
@@ -3680,7 +3680,7 @@ export interface CallEndedEvent {
   /**
    * The list of members in the call
    */
-  members?: MemberResponse[];
+  members?: Array<MemberResponse>;
 
   /**
    * User response object
@@ -3865,7 +3865,7 @@ export interface CallMemberAddedEvent {
   /**
    * the members added to this call
    */
-  members: MemberResponse[];
+  members: Array<MemberResponse>;
 
   /**
    * Represents a call
@@ -3886,7 +3886,7 @@ export interface CallMemberRemovedEvent {
   /**
    * the list of member IDs removed from the call
    */
-  members: string[];
+  members: Array<string>;
 
   /**
    * Represents a call
@@ -3907,7 +3907,7 @@ export interface CallMemberUpdatedEvent {
   /**
    * The list of members that were updated
    */
-  members: MemberResponse[];
+  members: Array<MemberResponse>;
 
   /**
    * Represents a call
@@ -3928,7 +3928,7 @@ export interface CallMemberUpdatedPermissionEvent {
   /**
    * The list of members that were updated
    */
-  members: MemberResponse[];
+  members: Array<MemberResponse>;
 
   /**
    * Represents a call
@@ -3938,7 +3938,7 @@ export interface CallMemberUpdatedPermissionEvent {
   /**
    * The capabilities by role for this call
    */
-  capabilities_by_role: Record<string, string[]>;
+  capabilities_by_role: Record<string, Array<string>>;
 
   /**
    * The type of event: "call.member_added" in this case
@@ -3961,7 +3961,7 @@ export interface CallMissedEvent {
   /**
    * List of members who missed the call
    */
-  members: MemberResponse[];
+  members: Array<MemberResponse>;
 
   /**
    * Represents a call
@@ -4039,7 +4039,7 @@ export interface CallNotificationEvent {
   /**
    * Call members
    */
-  members: MemberResponse[];
+  members: Array<MemberResponse>;
 
   /**
    * Represents a call
@@ -4058,11 +4058,11 @@ export interface CallNotificationEvent {
 }
 
 export interface CallParticipantCountReport {
-  histogram: ReportByHistogramBucket[];
+  histogram: Array<ReportByHistogramBucket>;
 }
 
 export interface CallParticipantCountReportResponse {
-  daily: DailyAggregateCallParticipantCountReportResponse[];
+  daily: Array<DailyAggregateCallParticipantCountReportResponse>;
 }
 
 export interface CallParticipantResponse {
@@ -4241,7 +4241,7 @@ export interface CallRequest {
 
   video?: boolean;
 
-  members?: MemberRequest[];
+  members?: Array<MemberRequest>;
 
   /**
    * User request object
@@ -4291,7 +4291,7 @@ export interface CallResponse {
    */
   updated_at: Date;
 
-  blocked_user_ids: string[];
+  blocked_user_ids: Array<string>;
 
   /**
    * User response object
@@ -4353,7 +4353,7 @@ export interface CallRingEvent {
   /**
    * Call members
    */
-  members: MemberResponse[];
+  members: Array<MemberResponse>;
 
   /**
    * Represents a call
@@ -4440,7 +4440,7 @@ export interface CallRtmpBroadcastStoppedEvent {
 export interface CallRuleActionSequence {
   violation_number?: number;
 
-  actions?: string[];
+  actions?: Array<string>;
 
   call_options?: CallActionOptions;
 }
@@ -4537,7 +4537,7 @@ export interface CallSessionResponse {
 
   id: string;
 
-  participants: CallParticipantResponse[];
+  participants: Array<CallParticipantResponse>;
 
   accepted_by: Record<string, Date>;
 
@@ -4698,9 +4698,9 @@ export interface CallStateResponseFields {
   /**
    * List of call members
    */
-  members: MemberResponse[];
+  members: Array<MemberResponse>;
 
-  own_capabilities: OwnCapability[];
+  own_capabilities: Array<OwnCapability>;
 
   /**
    * Represents a call
@@ -4751,11 +4751,11 @@ export interface CallStatsMapPublisher {
 }
 
 export interface CallStatsMapPublishers {
-  publishers: CallStatsMapPublisher[];
+  publishers: Array<CallStatsMapPublisher>;
 }
 
 export interface CallStatsMapSFUs {
-  locations: SFULocationResponse[];
+  locations: Array<SFULocationResponse>;
 }
 
 export interface CallStatsMapSubscriber {
@@ -4771,21 +4771,21 @@ export interface CallStatsMapSubscriber {
 }
 
 export interface CallStatsMapSubscribers {
-  locations: CallStatsMapLocation[];
+  locations: Array<CallStatsMapLocation>;
 
-  participants?: CallStatsMapSubscriber[];
+  participants?: Array<CallStatsMapSubscriber>;
 }
 
 export interface CallStatsParticipant {
   user_id: string;
 
-  sessions: CallStatsParticipantSession[];
+  sessions: Array<CallStatsParticipantSession>;
 
   latest_activity_at?: Date;
 
   name?: string;
 
-  roles?: string[];
+  roles?: Array<string>;
 }
 
 export interface CallStatsParticipantCounts {
@@ -4891,7 +4891,7 @@ export interface CallStatsReportReadyEvent {
   /**
    * Top participant sessions overview
    */
-  participants_overview?: CallStatsParticipant[];
+  participants_overview?: Array<CallStatsParticipant>;
 }
 
 export interface CallStatsReportSummaryResponse {
@@ -5039,7 +5039,7 @@ export interface CallTypeResponse {
   /**
    * the permissions granted to each role
    */
-  grants: Record<string, string[]>;
+  grants: Record<string, Array<string>>;
 
   notification_settings: NotificationSettingsResponse;
 
@@ -5068,7 +5068,7 @@ export interface CallUpdatedEvent {
   /**
    * The capabilities by role for this call
    */
-  capabilities_by_role: Record<string, string[]>;
+  capabilities_by_role: Record<string, Array<string>>;
 
   /**
    * The type of event: "call.updated" in this case
@@ -5125,7 +5125,7 @@ export interface CallUserMutedEvent {
 
   reason: string;
 
-  muted_user_ids: string[];
+  muted_user_ids: Array<string>;
 
   /**
    * The type of event: "call.user_muted" in this case
@@ -5144,7 +5144,7 @@ export interface CallsPerDayReport {
 }
 
 export interface CallsPerDayReportResponse {
-  daily: DailyAggregateCallsPerDayReportResponse[];
+  daily: Array<DailyAggregateCallsPerDayReportResponse>;
 }
 
 export interface CampaignChannelMember {
@@ -5162,9 +5162,9 @@ export interface CampaignChannelTemplate {
 
   team?: string;
 
-  members?: string[];
+  members?: Array<string>;
 
-  members_template?: CampaignChannelMember[];
+  members_template?: Array<CampaignChannelMember>;
 
   custom?: Record<string, any>;
 }
@@ -5188,7 +5188,7 @@ export interface CampaignMessageTemplate {
 
   searchable?: boolean;
 
-  attachments?: Attachment[];
+  attachments?: Array<Attachment>;
 
   custom?: Record<string, any>;
 }
@@ -5220,13 +5220,13 @@ export interface CampaignResponse {
 
   updated_at: Date;
 
-  segment_ids: string[];
+  segment_ids: Array<string>;
 
-  segments: Segment[];
+  segments: Array<Segment>;
 
-  user_ids: string[];
+  user_ids: Array<string>;
 
-  users: UserResponse[];
+  users: Array<UserResponse>;
 
   stats: CampaignStatsResponse;
 
@@ -5327,7 +5327,7 @@ export interface ChannelBatchCompletedEvent {
 
   task_id: string;
 
-  failed_channels: FailedChannelUpdates[];
+  failed_channels: Array<FailedChannelUpdates>;
 
   custom: Record<string, any>;
 
@@ -5357,7 +5357,7 @@ export interface ChannelBatchStartedEvent {
 
   task_id: string;
 
-  failed_channels: FailedChannelUpdates[];
+  failed_channels: Array<FailedChannelUpdates>;
 
   custom: Record<string, any>;
 
@@ -5386,7 +5386,7 @@ export interface ChannelBatchUpdateRequest {
    */
   filter: Record<string, any>;
 
-  members?: ChannelBatchMemberRequest[];
+  members?: Array<ChannelBatchMemberRequest>;
 
   data?: ChannelDataUpdate;
 }
@@ -5456,7 +5456,7 @@ export interface ChannelConfig {
   /**
    * List of commands that channel supports
    */
-  commands: string[];
+  commands: Array<string>;
 
   blocklist?: string;
 
@@ -5468,9 +5468,9 @@ export interface ChannelConfig {
 
   push_level?: 'all' | 'all_mentions' | 'mentions' | 'direct_mentions' | 'none';
 
-  allowed_flag_reasons?: string[];
+  allowed_flag_reasons?: Array<string>;
 
-  blocklists?: BlockListOptions[];
+  blocklists?: Array<BlockListOptions>;
 
   /**
    * Sets thresholds for AI moderation
@@ -5544,11 +5544,11 @@ export interface ChannelConfigOverrides {
   /**
    * List of commands that channel supports
    */
-  commands?: string[];
+  commands?: Array<string>;
 
   chat_preferences?: ChatPreferences;
 
-  grants?: Record<string, string[]>;
+  grants?: Record<string, Array<string>>;
 }
 
 export interface ChannelConfigWithInfo {
@@ -5604,7 +5604,7 @@ export interface ChannelConfigWithInfo {
 
   user_message_reminders: boolean;
 
-  commands: Command[];
+  commands: Array<Command>;
 
   blocklist?: string;
 
@@ -5616,9 +5616,9 @@ export interface ChannelConfigWithInfo {
 
   push_level?: 'all' | 'all_mentions' | 'mentions' | 'direct_mentions' | 'none';
 
-  allowed_flag_reasons?: string[];
+  allowed_flag_reasons?: Array<string>;
 
-  blocklists?: BlockListOptions[];
+  blocklists?: Array<BlockListOptions>;
 
   /**
    * Sets thresholds for AI moderation
@@ -5627,7 +5627,7 @@ export interface ChannelConfigWithInfo {
 
   chat_preferences?: ChatPreferences;
 
-  grants?: Record<string, string[]>;
+  grants?: Record<string, Array<string>>;
 }
 
 export interface ChannelContextResponse {
@@ -5846,7 +5846,7 @@ export interface ChannelGetOrCreateRequest {
   /**
    * Top-level keys of the message sender's channel-member custom data to include under member.custom (max 8 keys, 64 chars each)
    */
-  member_custom_include?: string[];
+  member_custom_include?: Array<string>;
 
   data?: ChannelInput;
 
@@ -5941,11 +5941,11 @@ export interface ChannelInput {
 
   truncated_by_id?: string;
 
-  filter_tags?: string[];
+  filter_tags?: Array<string>;
 
-  invites?: ChannelMemberRequest[];
+  invites?: Array<ChannelMemberRequest>;
 
-  members?: ChannelMemberRequest[];
+  members?: Array<ChannelMemberRequest>;
 
   /**
    * Channel configuration overrides
@@ -5971,9 +5971,9 @@ export interface ChannelInputRequest {
 
   team?: string;
 
-  invites?: ChannelMemberRequest[];
+  invites?: Array<ChannelMemberRequest>;
 
-  members?: ChannelMemberRequest[];
+  members?: Array<ChannelMemberRequest>;
 
   /**
    * Channel configuration overrides
@@ -6101,7 +6101,7 @@ export interface ChannelMemberResponse {
 
   user_id?: string;
 
-  deleted_messages?: string[];
+  deleted_messages?: Array<string>;
 
   /**
    * User response object
@@ -6119,7 +6119,7 @@ export interface ChannelMessagesResponse {
   /**
    * List of messages
    */
-  messages: MessageResponse[];
+  messages: Array<MessageResponse>;
 
   /**
    * Represents channel in chat
@@ -6192,7 +6192,7 @@ export interface ChannelMutedEvent {
   /**
    * The mute objects
    */
-  mutes?: ChannelMute[];
+  mutes?: Array<ChannelMute>;
 
   mute?: ChannelMute;
 
@@ -6366,17 +6366,17 @@ export interface ChannelResponse {
   /**
    * List of filter tags associated with the channel
    */
-  filter_tags?: string[];
+  filter_tags?: Array<string>;
 
   /**
    * List of channel members (max 100)
    */
-  members?: ChannelMemberResponse[];
+  members?: Array<ChannelMemberResponse>;
 
   /**
    * List of channel capabilities of authenticated user
    */
-  own_capabilities?: ChannelOwnCapability[];
+  own_capabilities?: Array<ChannelOwnCapability>;
 
   config?: ChannelConfigWithInfo;
 
@@ -6394,13 +6394,13 @@ export interface ChannelResponse {
 export interface ChannelStateResponse {
   duration: string;
 
-  members: ChannelMemberResponse[];
+  members: Array<ChannelMemberResponse>;
 
-  messages: MessageResponse[];
+  messages: Array<MessageResponse>;
 
-  pinned_messages: MessageResponse[];
+  pinned_messages: Array<MessageResponse>;
 
-  threads: ThreadStateResponse[];
+  threads: Array<ThreadStateResponse>;
 
   hidden?: boolean;
 
@@ -6408,13 +6408,13 @@ export interface ChannelStateResponse {
 
   watcher_count?: number;
 
-  active_live_locations?: SharedLocationResponseData[];
+  active_live_locations?: Array<SharedLocationResponseData>;
 
-  pending_messages?: PendingMessageResponse[];
+  pending_messages?: Array<PendingMessageResponse>;
 
-  read?: ReadStateResponse[];
+  read?: Array<ReadStateResponse>;
 
-  watchers?: UserResponse[];
+  watchers?: Array<UserResponse>;
 
   /**
    * Represents channel in chat
@@ -6432,19 +6432,19 @@ export interface ChannelStateResponseFields {
   /**
    * List of channel members
    */
-  members: ChannelMemberResponse[];
+  members: Array<ChannelMemberResponse>;
 
   /**
    * List of channel messages
    */
-  messages: MessageResponse[];
+  messages: Array<MessageResponse>;
 
   /**
    * List of pinned messages in the channel
    */
-  pinned_messages: MessageResponse[];
+  pinned_messages: Array<MessageResponse>;
 
-  threads: ThreadStateResponse[];
+  threads: Array<ThreadStateResponse>;
 
   /**
    * Whether this channel is hidden or not
@@ -6464,22 +6464,22 @@ export interface ChannelStateResponseFields {
   /**
    * Active live locations in the channel
    */
-  active_live_locations?: SharedLocationResponseData[];
+  active_live_locations?: Array<SharedLocationResponseData>;
 
   /**
    * Pending messages that this user has sent
    */
-  pending_messages?: PendingMessageResponse[];
+  pending_messages?: Array<PendingMessageResponse>;
 
   /**
    * List of read states
    */
-  read?: ReadStateResponse[];
+  read?: Array<ReadStateResponse>;
 
   /**
    * List of user who is watching the channel
    */
-  watchers?: UserResponse[];
+  watchers?: Array<UserResponse>;
 
   /**
    * Represents channel in chat
@@ -6605,11 +6605,11 @@ export interface ChannelTypeConfig {
 
   user_message_reminders: boolean;
 
-  commands: Command[];
+  commands: Array<Command>;
 
-  permissions: PolicyRequest[];
+  permissions: Array<PolicyRequest>;
 
-  grants: Record<string, string[]>;
+  grants: Record<string, Array<string>>;
 
   blocklist?: string;
 
@@ -6621,9 +6621,9 @@ export interface ChannelTypeConfig {
 
   push_level?: 'all' | 'all_mentions' | 'mentions' | 'direct_mentions' | 'none';
 
-  allowed_flag_reasons?: string[];
+  allowed_flag_reasons?: Array<string>;
 
-  blocklists?: BlockListOptions[];
+  blocklists?: Array<BlockListOptions>;
 
   /**
    * Sets thresholds for AI moderation
@@ -6682,7 +6682,7 @@ export interface ChannelUnmutedEvent {
   /**
    * The mute objects
    */
-  mutes?: ChannelMute[];
+  mutes?: Array<ChannelMute>;
 
   mute?: ChannelMute;
 
@@ -6827,9 +6827,9 @@ export interface ChatDraftPayloadResponse {
 
   type?: string;
 
-  attachments?: Attachment[];
+  attachments?: Array<Attachment>;
 
-  mentioned_users?: UserResponse[];
+  mentioned_users?: Array<UserResponse>;
 }
 
 export interface ChatDraftResponse {
@@ -6875,15 +6875,15 @@ export interface ChatMessageResponse {
 
   updated_at: Date;
 
-  attachments: Attachment[];
+  attachments: Array<Attachment>;
 
-  latest_reactions: ChatReactionResponse[];
+  latest_reactions: Array<ChatReactionResponse>;
 
-  mentioned_users: UserResponse[];
+  mentioned_users: Array<UserResponse>;
 
-  own_reactions: ChatReactionResponse[];
+  own_reactions: Array<ChatReactionResponse>;
 
-  restricted_visibility: string[];
+  restricted_visibility: Array<string>;
 
   custom: Record<string, any>;
 
@@ -6918,19 +6918,19 @@ export interface ChatMessageResponse {
 
   show_in_channel?: boolean;
 
-  mentioned_group_ids?: string[];
+  mentioned_group_ids?: Array<string>;
 
-  mentioned_groups?: UserGroupResponse[];
+  mentioned_groups?: Array<UserGroupResponse>;
 
-  mentioned_roles?: string[];
+  mentioned_roles?: Array<string>;
 
-  thread_participants?: UserResponse[];
+  thread_participants?: Array<UserResponse>;
 
   draft?: ChatDraftResponse;
 
   i18n?: Record<string, string>;
 
-  image_labels?: Record<string, string[]>;
+  image_labels?: Record<string, Array<string>>;
 
   member?: ChannelMemberPartialResponse;
 
@@ -6963,11 +6963,11 @@ export interface ChatModerationV2Response {
 
   semantic_filter_matched?: string;
 
-  blocklists_matched?: string[];
+  blocklists_matched?: Array<string>;
 
-  image_harms?: string[];
+  image_harms?: Array<string>;
 
-  text_harms?: string[];
+  text_harms?: Array<string>;
 }
 
 export interface ChatPreferences {
@@ -7029,7 +7029,7 @@ export interface ChatReactionGroupResponse {
 
   sum_scores: number;
 
-  latest_reactions_by: ChatReactionGroupUserResponse[];
+  latest_reactions_by: Array<ChatReactionGroupUserResponse>;
 }
 
 export interface ChatReactionGroupUserResponse {
@@ -7191,7 +7191,7 @@ export interface CheckPushResponse {
   /**
    * List of general errors
    */
-  general_errors?: string[];
+  general_errors?: Array<string>;
 
   /**
    * Object with device errors
@@ -7275,7 +7275,7 @@ export interface CheckResponse {
   /**
    * All moderation rules triggered by this check (content, user, and call rules), with their resolved actions
    */
-  triggered_rules?: TriggeredRuleResponse[];
+  triggered_rules?: Array<TriggeredRuleResponse>;
 
   item?: ReviewQueueItemResponse;
 
@@ -7382,7 +7382,7 @@ export interface Classification {
 
   severity?: string;
 
-  subclassifications?: Classification[];
+  subclassifications?: Array<Classification>;
 }
 
 export interface ClientEvent {
@@ -7553,7 +7553,7 @@ export interface ClosedCaptionRuleParameters {
 
   time_window?: string;
 
-  harm_labels?: string[];
+  harm_labels?: Array<string>;
 
   llm_harm_labels?: Record<string, string>;
 }
@@ -7862,12 +7862,12 @@ export interface CommentResponse {
   /**
    * Users mentioned in the comment
    */
-  mentioned_users: UserResponse[];
+  mentioned_users: Array<UserResponse>;
 
   /**
    * Current user's reactions to this activity
    */
-  own_reactions: FeedsReactionResponse[];
+  own_reactions: Array<FeedsReactionResponse>;
 
   /**
    * User response object
@@ -7902,12 +7902,12 @@ export interface CommentResponse {
   /**
    * Attachments associated with the comment
    */
-  attachments?: Attachment[];
+  attachments?: Array<Attachment>;
 
   /**
    * Recent reactions to the comment
    */
-  latest_reactions?: FeedsReactionResponse[];
+  latest_reactions?: Array<FeedsReactionResponse>;
 
   /**
    * Custom data for the comment
@@ -8057,14 +8057,14 @@ export interface ConfigOverridesRequest {
   /**
    * List of available commands
    */
-  commands?: string[];
+  commands?: Array<string>;
 
   chat_preferences?: ChatPreferences;
 
   /**
    * Permission grants modifiers
    */
-  grants?: Record<string, string[]>;
+  grants?: Record<string, Array<string>>;
 }
 
 export interface ConfigResponse {
@@ -8093,17 +8093,17 @@ export interface ConfigResponse {
    */
   updated_at: Date;
 
-  supported_video_call_harm_types: string[];
+  supported_video_call_harm_types: Array<string>;
 
   /**
    * Configurable image moderation label definitions for dashboard rendering
    */
-  ai_image_label_definitions?: AIImageLabelDefinition[];
+  ai_image_label_definitions?: Array<AIImageLabelDefinition>;
 
   /**
    * Names of Bodyguard credential profiles registered on this app. The dashboard uses this list to render the profile picker on the AI Text section.
    */
-  available_bodyguard_profiles?: BodyguardProfileSummary[];
+  available_bodyguard_profiles?: Array<BodyguardProfileSummary>;
 
   ai_audio_config?: AIAudioConfigResponse;
 
@@ -8112,7 +8112,7 @@ export interface ConfigResponse {
   /**
    * Available L2 subclassifications per L1 image moderation label, based on the active provider
    */
-  ai_image_subclassifications?: Record<string, string[]>;
+  ai_image_subclassifications?: Record<string, Array<string>>;
 
   ai_text_config?: AITextConfig;
 
@@ -8178,7 +8178,7 @@ export interface CountByMinuteResponse {
 export interface Coverage {
   publisher_encoding_profiles: number;
 
-  absent: AbsentMetric[];
+  absent: Array<AbsentMetric>;
 
   metrics_pct: MetricsPct;
 }
@@ -8192,7 +8192,7 @@ export interface CreateBlockListRequest {
   /**
    * List of words to block
    */
-  words: string[];
+  words: Array<string>;
 
   is_confusable_folding_enabled?: boolean;
 
@@ -8247,7 +8247,7 @@ export interface CreateCallTypeRequest {
   /**
    * the permissions granted to each role
    */
-  grants?: Record<string, string[]>;
+  grants?: Record<string, Array<string>>;
 
   notification_settings?: NotificationSettingsRequest;
 
@@ -8275,7 +8275,7 @@ export interface CreateCallTypeResponse {
   /**
    * the permissions granted to each role
    */
-  grants: Record<string, string[]>;
+  grants: Record<string, Array<string>>;
 
   notification_settings: NotificationSettingsResponse;
 
@@ -8342,12 +8342,12 @@ export interface CreateCampaignRequest {
   /**
    * The IDs of the segments to send the campaign to. Duplicate user IDs are removed. Use either user_ids or segment_ids, not both
    */
-  segment_ids?: string[];
+  segment_ids?: Array<string>;
 
   /**
    * The userIDs to send the campaign to. Use either segment ids or user ids not both
    */
-  user_ids?: string[];
+  user_ids?: Array<string>;
 
   channel_template?: CampaignChannelTemplate;
 }
@@ -8502,24 +8502,24 @@ export interface CreateChannelTypeRequest {
   /**
    * Blocklists
    */
-  blocklists?: BlockListOptions[];
+  blocklists?: Array<BlockListOptions>;
 
   /**
    * List of commands that channel supports
    */
-  commands?: string[];
+  commands?: Array<string>;
 
   /**
    * List of permissions for the channel type
    */
-  permissions?: PolicyRequest[];
+  permissions?: Array<PolicyRequest>;
 
   chat_preferences?: ChatPreferences;
 
   /**
    * List of grants for the channel type
    */
-  grants?: Record<string, string[]>;
+  grants?: Record<string, Array<string>>;
 }
 
 export interface CreateChannelTypeResponse {
@@ -8577,11 +8577,11 @@ export interface CreateChannelTypeResponse {
 
   user_message_reminders: boolean;
 
-  commands: string[];
+  commands: Array<string>;
 
-  permissions: PolicyRequest[];
+  permissions: Array<PolicyRequest>;
 
-  grants: Record<string, string[]>;
+  grants: Record<string, Array<string>>;
 
   blocklist?: string;
 
@@ -8593,9 +8593,9 @@ export interface CreateChannelTypeResponse {
 
   push_level?: 'all' | 'all_mentions' | 'mentions' | 'direct_mentions' | 'none';
 
-  allowed_flag_reasons?: string[];
+  allowed_flag_reasons?: Array<string>;
 
-  blocklists?: BlockListOptions[];
+  blocklists?: Array<BlockListOptions>;
 
   /**
    * Sets thresholds for AI moderation
@@ -8609,7 +8609,7 @@ export interface CreateCollectionsRequest {
   /**
    * List of collections to create
    */
-  collections: CollectionRequest[];
+  collections: Array<CollectionRequest>;
 
   user_id?: string;
 
@@ -8625,7 +8625,7 @@ export interface CreateCollectionsResponse {
   /**
    * List of created collections
    */
-  collections: CollectionResponse[];
+  collections: Array<CollectionResponse>;
 }
 
 export interface CreateCommandRequest {
@@ -8755,12 +8755,12 @@ export interface CreateFeedGroupRequest {
   /**
    * Configuration for activity processors
    */
-  activity_processors?: ActivityProcessorConfig[];
+  activity_processors?: Array<ActivityProcessorConfig>;
 
   /**
    * Configuration for activity selectors
    */
-  activity_selectors?: ActivitySelectorConfig[];
+  activity_selectors?: Array<ActivitySelectorConfig>;
 
   activity_filter?: ActivityFilterConfig;
 
@@ -8795,7 +8795,7 @@ export interface CreateFeedViewRequest {
   /**
    * Configuration for selecting activities
    */
-  activity_selectors?: ActivitySelectorConfig[];
+  activity_selectors?: Array<ActivitySelectorConfig>;
 
   aggregation?: AggregationConfig;
 
@@ -8812,7 +8812,7 @@ export interface CreateFeedsBatchRequest {
   /**
    * List of feeds to create
    */
-  feeds: FeedRequest[];
+  feeds: Array<FeedRequest>;
 
   /**
    * If true, enriches the created feeds with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
@@ -8826,7 +8826,7 @@ export interface CreateFeedsBatchResponse {
   /**
    * List of created feeds
    */
-  feeds: FeedResponse[];
+  feeds: Array<FeedResponse>;
 }
 
 export interface CreateGuestRequest {
@@ -8943,7 +8943,7 @@ export interface CreateMembershipLevelRequest {
   /**
    * Activity tags this membership level gives access to
    */
-  tags?: string[];
+  tags?: Array<string>;
 
   /**
    * Custom data for the membership level
@@ -8981,7 +8981,7 @@ export interface CreatePolicyTestSetRequest {
   /**
    * Messages to test; capped at 1000. Mutually exclusive with seed
    */
-  rows?: PolicyTestRow[];
+  rows?: Array<PolicyTestRow>;
 
   seed?: PolicyTestSeedSpec;
 }
@@ -9044,7 +9044,7 @@ export interface CreatePollRequest {
 
   voting_visibility?: 'anonymous' | 'public';
 
-  options?: PollOptionInput[];
+  options?: Array<PollOptionInput>;
 
   /**
    * Custom data for this object
@@ -9055,6 +9055,40 @@ export interface CreatePollRequest {
    * User request object
    */
   user?: UserRequest;
+}
+
+export interface CreatePredefinedFilterRequest {
+  /**
+   * The unique name of the predefined filter (alphanumeric, _, - only)
+   */
+  name: string;
+
+  /**
+   * The operation this filter is for (e.g., QueryChannels)
+   */
+
+  operation: 'QueryChannels';
+
+  /**
+   * Filter to apply to the query
+   */
+  filter: Record<string, any>;
+
+  /**
+   * The description of the predefined filter
+   */
+  description?: string;
+
+  sort?: Array<Record<string, any>>;
+}
+
+export interface CreatePredefinedFilterResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
+
+  predefined_filter?: PredefinedFilterResponse;
 }
 
 export interface CreateQueueRequest {
@@ -9112,7 +9146,7 @@ export interface CreateSIPTrunkRequest {
   /**
    * Phone numbers associated with this SIP trunk
    */
-  numbers: string[];
+  numbers: Array<string>;
 
   /**
    * Optional password for SIP trunk authentication
@@ -9122,7 +9156,7 @@ export interface CreateSIPTrunkRequest {
   /**
    * Optional list of allowed IPv4/IPv6 addresses or CIDR blocks
    */
-  allowed_ips?: string[];
+  allowed_ips?: Array<string>;
 }
 
 export interface CreateSIPTrunkResponse {
@@ -9205,7 +9239,7 @@ export interface CreateUserGroupRequest {
   /**
    * Optional initial list of user IDs to add as members
    */
-  member_ids?: string[];
+  member_ids?: Array<string>;
 }
 
 export interface CreateUserGroupResponse {
@@ -9240,7 +9274,7 @@ export interface CustomCheckFlag {
   /**
    * Labels from various moderation sources
    */
-  labels?: string[];
+  labels?: Array<string>;
 
   /**
    * Additional metadata for the flag
@@ -9262,7 +9296,7 @@ export interface CustomCheckRequest {
   /**
    * List of custom check flags (1-10 flags required)
    */
-  flags: CustomCheckFlag[];
+  flags: Array<CustomCheckFlag>;
 
   /**
    * ID of the user who created the entity (required for non-message entities)
@@ -9402,7 +9436,7 @@ export interface DailyMetricStatsResponse {
   /**
    * Array of daily metric values
    */
-  daily: DailyMetricResponse[];
+  daily: Array<DailyMetricResponse>;
 }
 
 export interface DailyValue {
@@ -9457,7 +9491,7 @@ export interface DeactivateUsersRequest {
   /**
    * User IDs to deactivate
    */
-  user_ids: string[];
+  user_ids: Array<string>;
 
   /**
    * ID of the user who deactivated the users
@@ -9526,7 +9560,7 @@ export interface DeleteActivitiesRequest {
   /**
    * List of activity IDs to delete
    */
-  ids: string[];
+  ids: Array<string>;
 
   /**
    * Whether to also delete any notification activities created from mentions in these activities
@@ -9552,7 +9586,7 @@ export interface DeleteActivitiesResponse {
   /**
    * List of activity IDs that were successfully deleted
    */
-  deleted_ids: string[];
+  deleted_ids: Array<string>;
 }
 
 export interface DeleteActivityReactionResponse {
@@ -9640,7 +9674,7 @@ export interface DeleteChannelsRequest {
   /**
    * All channels that should be deleted
    */
-  cids: string[];
+  cids: Array<string>;
 
   /**
    * Specify if channels and all ressources should be hard deleted
@@ -9772,7 +9806,7 @@ export interface DeleteFeedsBatchRequest {
   /**
    * List of fully qualified feed IDs (format: group_id:feed_id) to delete
    */
-  feeds: string[];
+  feeds: Array<string>;
 
   /**
    * Whether to permanently delete the feeds instead of soft delete
@@ -9932,7 +9966,7 @@ export interface DeleteSegmentTargetsRequest {
   /**
    * Target IDs
    */
-  target_ids: string[];
+  target_ids: Array<string>;
 }
 
 export interface DeleteTranscriptionResponse {
@@ -10016,7 +10050,7 @@ export interface DeleteUsersRequest {
   /**
    * IDs of users to delete
    */
-  user_ids: string[];
+  user_ids: Array<string>;
 
   /**
    * Calls delete mode.
@@ -10223,12 +10257,12 @@ export interface DraftPayloadResponse {
   /**
    * Array of message attachments
    */
-  attachments?: Attachment[];
+  attachments?: Array<Attachment>;
 
   /**
    * List of mentioned users
    */
-  mentioned_users?: UserResponse[];
+  mentioned_users?: Array<UserResponse>;
 }
 
 export interface DraftResponse {
@@ -10263,17 +10297,17 @@ export interface EMAUStatsResponse {
   /**
    * Per-day unique engaged user counts
    */
-  daily: DailyMetricResponse[];
+  daily: Array<DailyMetricResponse>;
 
   /**
    * Rolling 30-day engaged user count snapshots
    */
-  last_30_days: DailyMetricResponse[];
+  last_30_days: Array<DailyMetricResponse>;
 
   /**
    * Calendar month-to-date engaged user count snapshots
    */
-  month_to_date: DailyMetricResponse[];
+  month_to_date: Array<DailyMetricResponse>;
 }
 
 export interface EdgeResponse {
@@ -10317,7 +10351,7 @@ export interface EgressRTMPResponse {
 export interface EgressResponse {
   broadcasting: boolean;
 
-  rtmps: EgressRTMPResponse[];
+  rtmps: Array<EgressRTMPResponse>;
 
   composite_recording?: CompositeRecordingResponse;
 
@@ -10335,7 +10369,7 @@ export interface EncodingProfile {
 
   source_file: string;
 
-  svc_modes: string[];
+  svc_modes: Array<string>;
 
   quality_limitation_durations_s: Record<string, number>;
 
@@ -10396,17 +10430,17 @@ export interface EnrichedActivity {
 
   verb?: string;
 
-  to?: string[];
+  to?: Array<string>;
 
   actor?: Data;
 
-  latest_reactions?: Record<string, EnrichedReaction[]>;
+  latest_reactions?: Record<string, Array<EnrichedReaction>>;
 
   object?: Data;
 
   origin?: Data;
 
-  own_reactions?: Record<string, EnrichedReaction[]>;
+  own_reactions?: Record<string, Array<EnrichedReaction>>;
 
   reaction_counts?: Record<string, number>;
 
@@ -10462,7 +10496,7 @@ export interface EnrichedReaction {
 
   parent?: string;
 
-  target_feeds?: string[];
+  target_feeds?: Array<string>;
 
   children_counts?: Record<string, number>;
 
@@ -10470,9 +10504,9 @@ export interface EnrichedReaction {
 
   data?: Record<string, any>;
 
-  latest_children?: Record<string, EnrichedReaction[]>;
+  latest_children?: Record<string, Array<EnrichedReaction>>;
 
-  own_children?: Record<string, EnrichedReaction[]>;
+  own_children?: Record<string, Array<EnrichedReaction>>;
 
   updated_at?: Time;
 
@@ -10615,9 +10649,9 @@ export interface EntityCreatorResponse {
 
   updated_at: Date;
 
-  blocked_user_ids: string[];
+  blocked_user_ids: Array<string>;
 
-  teams: string[];
+  teams: Array<string>;
 
   custom: Record<string, any>;
 
@@ -10639,7 +10673,7 @@ export interface EntityCreatorResponse {
 
   revoke_tokens_issued_before?: Date;
 
-  devices?: DeviceResponse[];
+  devices?: Array<DeviceResponse>;
 
   privacy_settings?: PrivacySettingsResponse;
 
@@ -10728,7 +10762,7 @@ export interface EventHook {
 
   webhook_url?: string;
 
-  event_types?: string[];
+  event_types?: Array<string>;
 
   callback?: AsyncModerationCallbackConfig;
 
@@ -10790,7 +10824,7 @@ export interface ExportChannelsRequest {
   /**
    * Export options for channels
    */
-  channels: ChannelExport[];
+  channels: Array<ChannelExport>;
 
   /**
    * Set if deleted message text should be cleared
@@ -10823,7 +10857,7 @@ export interface ExportChannelsRequest {
   /**
    * For csv format: subset of message columns to include (defaults to a standard set)
    */
-  include_fields?: string[];
+  include_fields?: Array<string>;
 }
 
 export interface ExportChannelsResponse {
@@ -10858,12 +10892,12 @@ export interface ExportUserResponse {
   /**
    * List of exported messages
    */
-  messages?: MessageResponse[];
+  messages?: Array<MessageResponse>;
 
   /**
    * List of exported reactions
    */
-  reactions?: ReactionResponse[];
+  reactions?: Array<ReactionResponse>;
 
   /**
    * User response object
@@ -10872,7 +10906,7 @@ export interface ExportUserResponse {
 }
 
 export interface ExportUsersRequest {
-  user_ids: string[];
+  user_ids: Array<string>;
 }
 
 export interface ExportUsersResponse {
@@ -10905,7 +10939,7 @@ export interface FCMPayload {
 export interface FailedChannelUpdates {
   reason: string;
 
-  cids: string[];
+  cids: Array<string>;
 }
 
 export interface FeedCreatedEvent {
@@ -10916,7 +10950,7 @@ export interface FeedCreatedEvent {
 
   fid: string;
 
-  members: FeedMemberResponse[];
+  members: Array<FeedMemberResponse>;
 
   custom: Record<string, any>;
 
@@ -10969,9 +11003,9 @@ export interface FeedGroup {
 
   updated_at: Date;
 
-  activity_processors: ActivityProcessorConfig[];
+  activity_processors: Array<ActivityProcessorConfig>;
 
-  activity_selectors: ActivitySelectorConfig[];
+  activity_selectors: Array<ActivitySelectorConfig>;
 
   custom: Record<string, any>;
 
@@ -11069,12 +11103,12 @@ export interface FeedGroupResponse {
   /**
    * Configuration for activity processors
    */
-  activity_processors?: ActivityProcessorConfig[];
+  activity_processors?: Array<ActivityProcessorConfig>;
 
   /**
    * Configuration for activity selectors
    */
-  activity_selectors?: ActivitySelectorConfigResponse[];
+  activity_selectors?: Array<ActivitySelectorConfigResponse>;
 
   activity_filter?: ActivityFilterConfig;
 
@@ -11126,9 +11160,9 @@ export interface FeedInput {
 
   visibility?: 'public' | 'visible' | 'followers' | 'members' | 'private';
 
-  filter_tags?: string[];
+  filter_tags?: Array<string>;
 
-  members?: FeedMemberRequest[];
+  members?: Array<FeedMemberRequest>;
 
   custom?: Record<string, any>;
 
@@ -11318,17 +11352,17 @@ export interface FeedOwnData {
   /**
    * Capabilities the current user has for this feed
    */
-  own_capabilities?: FeedOwnCapability[];
+  own_capabilities?: Array<FeedOwnCapability>;
 
   /**
    * Follow relationships where the feed owner's feeds are following the current user's feeds (up to 5 total)
    */
-  own_followings?: FollowResponse[];
+  own_followings?: Array<FollowResponse>;
 
   /**
    * Follow relationships where the current user's feeds are following this feed
    */
-  own_follows?: FollowResponse[];
+  own_follows?: Array<FollowResponse>;
 
   own_membership?: FeedMemberResponse;
 }
@@ -11368,12 +11402,12 @@ export interface FeedRequest {
   /**
    * Tags used for filtering feeds
    */
-  filter_tags?: string[];
+  filter_tags?: Array<string>;
 
   /**
    * Initial members for the feed
    */
-  members?: FeedMemberRequest[];
+  members?: Array<FeedMemberRequest>;
 
   /**
    * Custom data for the feed
@@ -11460,22 +11494,22 @@ export interface FeedResponse {
   /**
    * Tags used for filtering feeds
    */
-  filter_tags?: string[];
+  filter_tags?: Array<string>;
 
   /**
    * Capabilities the current user has for this feed
    */
-  own_capabilities?: FeedOwnCapability[];
+  own_capabilities?: Array<FeedOwnCapability>;
 
   /**
    * Follow relationships where the feed owner’s feeds are following the current user's feeds
    */
-  own_followings?: FollowResponse[];
+  own_followings?: Array<FollowResponse>;
 
   /**
    * Follow relationships where the current user's feeds are following this feed
    */
-  own_follows?: FollowResponse[];
+  own_follows?: Array<FollowResponse>;
 
   /**
    * Custom data for the feed
@@ -11568,22 +11602,22 @@ export interface FeedSuggestionResponse {
   /**
    * Tags used for filtering feeds
    */
-  filter_tags?: string[];
+  filter_tags?: Array<string>;
 
   /**
    * Capabilities the current user has for this feed
    */
-  own_capabilities?: FeedOwnCapability[];
+  own_capabilities?: Array<FeedOwnCapability>;
 
   /**
    * Follow relationships where the feed owner’s feeds are following the current user's feeds
    */
-  own_followings?: FollowResponse[];
+  own_followings?: Array<FollowResponse>;
 
   /**
    * Follow relationships where the current user's feeds are following this feed
    */
-  own_follows?: FollowResponse[];
+  own_follows?: Array<FollowResponse>;
 
   algorithm_scores?: Record<string, number>;
 
@@ -11632,7 +11666,7 @@ export interface FeedViewResponse {
   /**
    * Configured activity selectors
    */
-  activity_selectors?: ActivitySelectorConfigResponse[];
+  activity_selectors?: Array<ActivitySelectorConfigResponse>;
 
   aggregation?: AggregationConfig;
 
@@ -11648,12 +11682,12 @@ export interface FeedVisibilityResponse {
   /**
    * List of permission policies
    */
-  permissions: Permission[];
+  permissions: Array<Permission>;
 
   /**
    * Permission grants for each role
    */
-  grants: Record<string, string[]>;
+  grants: Record<string, Array<string>>;
 }
 
 export interface FeedsActivityLocation {
@@ -11731,7 +11765,7 @@ export interface FeedsFeedResponse {
 
   visibility?: string;
 
-  filter_tags?: string[];
+  filter_tags?: Array<string>;
 
   custom?: Record<string, any>;
 
@@ -11757,7 +11791,7 @@ export interface FeedsNotificationComment {
 
   user_id: string;
 
-  attachments?: Attachment[];
+  attachments?: Array<Attachment>;
 }
 
 export interface FeedsNotificationContext {
@@ -11775,7 +11809,7 @@ export interface FeedsNotificationParentActivity {
 
   user_id?: string;
 
-  attachments?: Attachment[];
+  attachments?: Array<Attachment>;
 }
 
 export interface FeedsNotificationTarget {
@@ -11789,7 +11823,7 @@ export interface FeedsNotificationTarget {
 
   user_id?: string;
 
-  attachments?: Attachment[];
+  attachments?: Array<Attachment>;
 
   comment?: FeedsNotificationComment;
 
@@ -11942,23 +11976,23 @@ export interface FeedsV3ActivityResponse {
 
   visibility: string;
 
-  attachments: Attachment[];
+  attachments: Array<Attachment>;
 
-  comments: FeedsV3CommentResponse[];
+  comments: Array<FeedsV3CommentResponse>;
 
-  feeds: string[];
+  feeds: Array<string>;
 
-  filter_tags: string[];
+  filter_tags: Array<string>;
 
-  interest_tags: string[];
+  interest_tags: Array<string>;
 
-  latest_reactions: FeedsReactionResponse[];
+  latest_reactions: Array<FeedsReactionResponse>;
 
-  mentioned_users: UserResponse[];
+  mentioned_users: Array<UserResponse>;
 
-  own_bookmarks: FeedsBookmarkResponse[];
+  own_bookmarks: Array<FeedsBookmarkResponse>;
 
-  own_reactions: FeedsReactionResponse[];
+  own_reactions: Array<FeedsReactionResponse>;
 
   collections: Record<string, FeedsEnrichedCollectionResponse>;
 
@@ -11995,9 +12029,9 @@ export interface FeedsV3ActivityResponse {
 
   visibility_tag?: string;
 
-  friend_reactions?: FeedsReactionResponse[];
+  friend_reactions?: Array<FeedsReactionResponse>;
 
-  latest_shares?: FeedsShareResponse[];
+  latest_shares?: Array<FeedsShareResponse>;
 
   current_feed?: FeedsFeedResponse;
 
@@ -12045,9 +12079,9 @@ export interface FeedsV3CommentResponse {
 
   upvote_count: number;
 
-  mentioned_users: UserResponse[];
+  mentioned_users: Array<UserResponse>;
 
-  own_reactions: FeedsReactionResponse[];
+  own_reactions: Array<FeedsReactionResponse>;
 
   /**
    * User response object
@@ -12064,9 +12098,9 @@ export interface FeedsV3CommentResponse {
 
   text?: string;
 
-  attachments?: Attachment[];
+  attachments?: Array<Attachment>;
 
-  latest_reactions?: FeedsReactionResponse[];
+  latest_reactions?: Array<FeedsReactionResponse>;
 
   custom?: Record<string, any>;
 
@@ -12088,13 +12122,13 @@ export interface Field {
 export interface FileUploadConfig {
   size_limit: number;
 
-  allowed_file_extensions?: string[];
+  allowed_file_extensions?: Array<string>;
 
-  allowed_mime_types?: string[];
+  allowed_mime_types?: Array<string>;
 
-  blocked_file_extensions?: string[];
+  blocked_file_extensions?: Array<string>;
 
-  blocked_mime_types?: string[];
+  blocked_mime_types?: Array<string>;
 }
 
 export interface FileUploadRequest {
@@ -12127,32 +12161,32 @@ export interface FilterConfigResponse {
   /**
    * LLM moderation labels available as filter values
    */
-  llm_labels: string[];
+  llm_labels: Array<string>;
 
   /**
    * AI image moderation labels available as filter values. Reflects the app's effective image taxonomy: custom Bodyguard taxonomy when enabled, otherwise the standard L1 label set.
    */
-  ai_image_labels?: string[];
+  ai_image_labels?: Array<string>;
 
   /**
    * AI text moderation labels available as filter values
    */
-  ai_text_labels?: string[];
+  ai_text_labels?: Array<string>;
 
   /**
    * Moderation config keys present in the queue, available as filter values
    */
-  config_keys?: string[];
+  config_keys?: Array<string>;
 
   /**
    * The moderation_payload.custom keys the app has configured as review-queue filter chips (via moderation_dashboard_preferences.filterable_custom_keys). Discovery hint for the dashboard only — the filter accepts any custom key regardless of this list.
    */
-  filterable_custom_keys?: string[];
+  filterable_custom_keys?: Array<string>;
 
   /**
    * AI image moderation labels available as filter values, as a map of L1 label to its L2 sub-labels. Reflects the app's effective image taxonomy: custom Bodyguard taxonomy when enabled, otherwise the standard catalogue of the org's enabled image providers.
    */
-  ai_image_taxonomy?: Record<string, string[]>;
+  ai_image_taxonomy?: Record<string, Array<string>>;
 }
 
 export interface FirebaseConfig {
@@ -12206,7 +12240,7 @@ export interface FlagFeedbackResponse {
 
   message_id: string;
 
-  labels: LabelResponse[];
+  labels: Array<LabelResponse>;
 }
 
 export interface FlagItemResponse {
@@ -12333,7 +12367,7 @@ export interface FlagUserOptions {
 }
 
 export interface FloodConfig {
-  allowlist?: string[];
+  allowlist?: Array<string>;
 
   identical?: FloodIdenticalConfig;
 
@@ -12355,7 +12389,7 @@ export interface FloodIdenticalRuleParameters {
 
   time_window?: string;
 
-  allowlist?: string[];
+  allowlist?: Array<string>;
 }
 
 export interface FloodSimilarConfig {
@@ -12377,14 +12411,14 @@ export interface FloodSimilarRuleParameters {
 
   time_window?: string;
 
-  allowlist?: string[];
+  allowlist?: Array<string>;
 }
 
 export interface FollowBatchRequest {
   /**
    * List of follow relationships to create
    */
-  follows: FollowRequest[];
+  follows: Array<FollowRequest>;
 
   /**
    * If true, auto-creates users referenced by source/target FIDs in the batch when they don't already exist. Server-side only. Defaults to false. This top-level field is the only supported batch/upsert create_users control.
@@ -12403,12 +12437,12 @@ export interface FollowBatchResponse {
   /**
    * List of newly created follow relationships
    */
-  created: FollowResponse[];
+  created: Array<FollowResponse>;
 
   /**
    * List of current follow relationships
    */
-  follows: FollowResponse[];
+  follows: Array<FollowResponse>;
 }
 
 export interface FollowCreatedEvent {
@@ -12658,15 +12692,15 @@ export interface FullUserResponse {
 
   updated_at: Date;
 
-  blocked_user_ids: string[];
+  blocked_user_ids: Array<string>;
 
-  channel_mutes: ChannelMute[];
+  channel_mutes: Array<ChannelMute>;
 
-  devices: DeviceResponse[];
+  devices: Array<DeviceResponse>;
 
-  mutes: UserMuteResponse[];
+  mutes: Array<UserMuteResponse>;
 
-  teams: string[];
+  teams: Array<string>;
 
   custom: Record<string, any>;
 
@@ -12688,7 +12722,7 @@ export interface FullUserResponse {
 
   revoke_tokens_issued_before?: Date;
 
-  latest_hidden_channels?: string[];
+  latest_hidden_channels?: Array<string>;
 
   privacy_settings?: PrivacySettingsResponse;
 
@@ -12722,19 +12756,19 @@ export interface GeofenceResponse {
 
   type?: string;
 
-  country_codes?: string[];
+  country_codes?: Array<string>;
 }
 
 export interface GeofenceSettings {
-  names: string[];
+  names: Array<string>;
 }
 
 export interface GeofenceSettingsRequest {
-  names?: string[];
+  names?: Array<string>;
 }
 
 export interface GeofenceSettingsResponse {
-  names: string[];
+  names: Array<string>;
 }
 
 export interface GetActionConfigResponse {
@@ -12743,7 +12777,7 @@ export interface GetActionConfigResponse {
   /**
    * Moderation action configs grouped by entity type, sorted by order ascending
    */
-  action_config: Record<string, ModerationActionConfigResponse[]>;
+  action_config: Record<string, Array<ModerationActionConfigResponse>>;
 }
 
 export interface GetActiveCallsStatusResponse {
@@ -12803,7 +12837,7 @@ export interface GetBlockedUsersResponse {
   /**
    * Array of blocked user object
    */
-  blocks: BlockedUserResponse[];
+  blocks: Array<BlockedUserResponse>;
 }
 
 export interface GetCallParticipantSessionMetricsResponse {
@@ -12824,7 +12858,7 @@ export interface GetCallParticipantSessionMetricsResponse {
 
   user_session_id?: string;
 
-  published_tracks?: PublishedTrackMetrics[];
+  published_tracks?: Array<PublishedTrackMetrics>;
 
   client?: SessionClient;
 }
@@ -12839,7 +12873,7 @@ export interface GetCallReportResponse {
 
   report: ReportResponse;
 
-  video_reactions?: VideoReactionsResponse[];
+  video_reactions?: Array<VideoReactionsResponse>;
 
   chat_activity?: ChatActivityStatsResponse;
 
@@ -12851,9 +12885,9 @@ export interface GetCallReportResponse {
 export interface GetCallResponse {
   duration: string;
 
-  members: MemberResponse[];
+  members: Array<MemberResponse>;
 
-  own_capabilities: OwnCapability[];
+  own_capabilities: Array<OwnCapability>;
 
   /**
    * Represents a call
@@ -12895,7 +12929,7 @@ export interface GetCallTypeResponse {
 
   updated_at: Date;
 
-  grants: Record<string, string[]>;
+  grants: Record<string, Array<string>>;
 
   notification_settings: NotificationSettingsResponse;
 
@@ -12973,11 +13007,11 @@ export interface GetChannelTypeResponse {
 
   user_message_reminders: boolean;
 
-  commands: Command[];
+  commands: Array<Command>;
 
-  permissions: PolicyRequest[];
+  permissions: Array<PolicyRequest>;
 
-  grants: Record<string, string[]>;
+  grants: Record<string, Array<string>>;
 
   blocklist?: string;
 
@@ -12989,9 +13023,9 @@ export interface GetChannelTypeResponse {
 
   push_level?: 'all' | 'all_mentions' | 'mentions' | 'direct_mentions' | 'none';
 
-  allowed_flag_reasons?: string[];
+  allowed_flag_reasons?: Array<string>;
 
-  blocklists?: BlockListOptions[];
+  blocklists?: Array<BlockListOptions>;
 
   /**
    * Sets thresholds for AI moderation
@@ -13028,7 +13062,7 @@ export interface GetCommentRepliesResponse {
   /**
    * Threaded listing of replies to the comment
    */
-  comments: ThreadedCommentResponse[];
+  comments: Array<ThreadedCommentResponse>;
 
   next?: string;
 
@@ -13052,7 +13086,7 @@ export interface GetCommentsResponse {
   /**
    * Threaded listing for the activity
    */
-  comments: ThreadedCommentResponse[];
+  comments: Array<ThreadedCommentResponse>;
 
   next?: string;
 
@@ -13092,11 +13126,11 @@ export interface GetDailyDigestResponse {
 
   schema_version?: string;
 
-  broadcasts?: BroadcastDigest[];
+  broadcasts?: Array<BroadcastDigest>;
 
-  call_sessions?: DailyDigestCallSessionSummary[];
+  call_sessions?: Array<DailyDigestCallSessionSummary>;
 
-  digest_kinds?: string[];
+  digest_kinds?: Array<string>;
 
   broadcast_rollup?: BroadcastDailyRollup;
 }
@@ -13116,7 +13150,7 @@ export interface GetEdgesResponse {
    */
   duration: string;
 
-  edges: EdgeResponse[];
+  edges: Array<EdgeResponse>;
 }
 
 export interface GetExternalStorageAWSS3Response {
@@ -13228,7 +13262,7 @@ export interface GetFollowSuggestionsResponse {
   /**
    * List of suggested feeds to follow
    */
-  suggestions: FeedSuggestionResponse[];
+  suggestions: Array<FeedSuggestionResponse>;
 
   algorithm_used?: string;
 }
@@ -13271,7 +13305,7 @@ export interface GetManyMessagesResponse {
   /**
    * List of messages
    */
-  messages: MessageResponse[];
+  messages: Array<MessageResponse>;
 }
 
 export interface GetMessageResponse {
@@ -13368,9 +13402,9 @@ export interface GetOGResponse {
    */
   type?: string;
 
-  actions?: Action[];
+  actions?: Array<Action>;
 
-  fields?: Field[];
+  fields?: Array<Field>;
 
   giphy?: Images;
 }
@@ -13401,9 +13435,9 @@ export interface GetOrCreateCallResponse {
 
   duration: string;
 
-  members: MemberResponse[];
+  members: Array<MemberResponse>;
 
-  own_capabilities: OwnCapability[];
+  own_capabilities: Array<OwnCapability>;
 
   /**
    * Represents a call
@@ -13422,12 +13456,12 @@ export interface GetOrCreateFeedGroupRequest {
   /**
    * Configuration for activity processors
    */
-  activity_processors?: ActivityProcessorConfig[];
+  activity_processors?: Array<ActivityProcessorConfig>;
 
   /**
    * Configuration for activity selectors
    */
-  activity_selectors?: ActivitySelectorConfig[];
+  activity_selectors?: Array<ActivitySelectorConfig>;
 
   activity_filter?: ActivityFilterConfig;
 
@@ -13513,17 +13547,17 @@ export interface GetOrCreateFeedResponse {
    */
   duration: string;
 
-  activities: ActivityResponse[];
+  activities: Array<ActivityResponse>;
 
-  aggregated_activities: AggregatedActivityResponse[];
+  aggregated_activities: Array<AggregatedActivityResponse>;
 
-  followers: FollowResponse[];
+  followers: Array<FollowResponse>;
 
-  following: FollowResponse[];
+  following: Array<FollowResponse>;
 
-  members: FeedMemberResponse[];
+  members: Array<FeedMemberResponse>;
 
-  pinned_activities: ActivityPinResponse[];
+  pinned_activities: Array<ActivityPinResponse>;
 
   feed: FeedResponse;
 
@@ -13544,7 +13578,7 @@ export interface GetOrCreateFeedViewRequest {
   /**
    * Configuration for selecting activities
    */
-  activity_selectors?: ActivitySelectorConfig[];
+  activity_selectors?: Array<ActivitySelectorConfig>;
 
   aggregation?: AggregationConfig;
 
@@ -13616,13 +13650,34 @@ export interface GetOrCreateUnfollowResponse {
   follow?: FollowResponse;
 }
 
+export interface GetPinnedMessagesResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
+
+  /**
+   * Messages
+   */
+  messages: Array<MessageResponse>;
+}
+
+export interface GetPredefinedFilterResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
+
+  predefined_filter?: PredefinedFilterResponse;
+}
+
 export interface GetPushTemplatesResponse {
   /**
    * Duration of the request in milliseconds
    */
   duration: string;
 
-  templates: PushTemplateResponse[];
+  templates: Array<PushTemplateResponse>;
 }
 
 export interface GetRateLimitsResponse {
@@ -13660,7 +13715,7 @@ export interface GetReactionsResponse {
   /**
    * List of reactions
    */
-  reactions: ReactionResponse[];
+  reactions: Array<ReactionResponse>;
 }
 
 export interface GetRepliesResponse {
@@ -13669,7 +13724,7 @@ export interface GetRepliesResponse {
    */
   duration: string;
 
-  messages: MessageResponse[];
+  messages: Array<MessageResponse>;
 }
 
 export interface GetRetentionPolicyResponse {
@@ -13678,7 +13733,7 @@ export interface GetRetentionPolicyResponse {
    */
   duration: string;
 
-  policies: RetentionPolicy[];
+  policies: Array<RetentionPolicy>;
 }
 
 export interface GetRetentionPolicyRunsRequest {
@@ -13691,7 +13746,7 @@ export interface GetRetentionPolicyRunsRequest {
   /**
    * Array of sort parameters
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter conditions to apply to the query
@@ -13705,7 +13760,7 @@ export interface GetRetentionPolicyRunsResponse {
    */
   duration: string;
 
-  runs: RetentionRunResponse[];
+  runs: Array<RetentionRunResponse>;
 
   next?: string;
 
@@ -13776,7 +13831,7 @@ export interface GetUserInterestsResponse {
   /**
    * Top-N interest tags sorted by descending count, then alphabetically by tag
    */
-  interests: InterestTagResponse[];
+  interests: Array<InterestTagResponse>;
 }
 
 export interface GoLiveRequest {
@@ -13819,7 +13874,7 @@ export interface GroupedChannelsBucket {
   /**
    * Channels returned for this bucket
    */
-  channels: ChannelStateResponseFields[];
+  channels: Array<ChannelStateResponseFields>;
 
   /**
    * Cursor for the next page of this group
@@ -13887,7 +13942,7 @@ export interface HLSSettings {
 
   enabled: boolean;
 
-  quality_tracks: string[];
+  quality_tracks: Array<string>;
 
   layout?: LayoutSettings;
 }
@@ -13896,7 +13951,7 @@ export interface HLSSettingsRequest {
   /**
    * Quality tracks for HLS. One of: 360p, 480p, 720p, 1080p, 1440p, portrait-360x640, portrait-480x854, portrait-720x1280, portrait-1080x1920, portrait-1440x2560
    */
-  quality_tracks: string[];
+  quality_tracks: Array<string>;
 
   /**
    * Whether HLS broadcasting should start automatically
@@ -13916,7 +13971,7 @@ export interface HLSSettingsResponse {
 
   enabled: boolean;
 
-  quality_tracks: string[];
+  quality_tracks: Array<string>;
 
   layout: LayoutSettingsResponse;
 }
@@ -13928,9 +13983,9 @@ export interface HarmConfig {
 
   threshold?: number;
 
-  action_sequences?: ActionSequence[];
+  action_sequences?: Array<ActionSequence>;
 
-  harm_types?: string[];
+  harm_types?: Array<string>;
 }
 
 export interface HideChannelRequest {
@@ -13983,7 +14038,7 @@ export interface IPFlagCountRuleParameters {
 
   time_window?: string;
 
-  harm_labels?: string[];
+  harm_labels?: Array<string>;
 }
 
 export interface ImageContentParameters {
@@ -13991,7 +14046,7 @@ export interface ImageContentParameters {
 
   min_confidence?: number;
 
-  harm_labels?: string[];
+  harm_labels?: Array<string>;
 }
 
 export interface ImageData {
@@ -14013,7 +14068,7 @@ export interface ImageRuleParameters {
 
   time_window?: string;
 
-  harm_labels?: string[];
+  harm_labels?: Array<string>;
 }
 
 export interface ImageSize {
@@ -14044,7 +14099,7 @@ export interface ImageUploadRequest {
   /**
    * field with JSON-encoded array of image size configurations
    */
-  upload_sizes?: ImageSize[];
+  upload_sizes?: Array<ImageSize>;
 
   user?: OnlyUserID;
 }
@@ -14062,7 +14117,7 @@ export interface ImageUploadResponse {
   /**
    * Array of image size configurations
    */
-  upload_sizes?: ImageSize[];
+  upload_sizes?: Array<ImageSize>;
 }
 
 export interface Images {
@@ -14082,7 +14137,7 @@ export interface Images {
 }
 
 export interface ImportBlockListRequest {
-  items: string[];
+  items: Array<string>;
 
   chunk_size?: number;
 }
@@ -14109,7 +14164,7 @@ export interface ImportTask {
 
   updated_at: Date;
 
-  history: ImportTaskHistory[];
+  history: Array<ImportTaskHistory>;
 
   size?: number;
 }
@@ -14175,7 +14230,7 @@ export interface Incident {
 export interface IndividualRecordSettings {
   mode: 'available' | 'disabled' | 'auto-on';
 
-  output_types?: string[];
+  output_types?: Array<string>;
 }
 
 export interface IndividualRecordingResponse {
@@ -14192,13 +14247,13 @@ export interface IndividualRecordingSettingsRequest {
   /**
    * Output types to include: audio_only, video_only, audio_video, screenshare_audio_only, screenshare_video_only, screenshare_audio_video
    */
-  output_types?: string[];
+  output_types?: Array<string>;
 }
 
 export interface IndividualRecordingSettingsResponse {
   mode: 'available' | 'disabled' | 'auto-on';
 
-  output_types?: string[];
+  output_types?: Array<string>;
 }
 
 export interface IngressAudioEncodingOptions {
@@ -14367,19 +14422,19 @@ export interface IngressStoppedEvent {
 }
 
 export interface IngressVideoEncodingOptions {
-  layers: IngressVideoLayer[];
+  layers: Array<IngressVideoLayer>;
 
   source?: IngressSource;
 }
 
 export interface IngressVideoEncodingOptionsRequest {
-  layers: IngressVideoLayerRequest[];
+  layers: Array<IngressVideoLayerRequest>;
 
   source: IngressSourceRequest;
 }
 
 export interface IngressVideoEncodingResponse {
-  layers: IngressVideoLayerResponse[];
+  layers: Array<IngressVideoLayerResponse>;
 
   source: IngressSourceResponse;
 }
@@ -14503,7 +14558,7 @@ export interface KeyframeOCRRuleParameters {
 
   time_window?: string;
 
-  harm_labels?: string[];
+  harm_labels?: Array<string>;
 }
 
 export interface KeyframeRuleParameters {
@@ -14513,7 +14568,7 @@ export interface KeyframeRuleParameters {
 
   time_window?: string;
 
-  harm_labels?: string[];
+  harm_labels?: Array<string>;
 }
 
 export interface KickUserRequest {
@@ -14573,7 +14628,7 @@ export interface LLMConfig {
 
   enabled?: boolean;
 
-  rules?: LLMRule[];
+  rules?: Array<LLMRule>;
 
   severity_descriptions?: Record<string, string>;
 }
@@ -14592,15 +14647,15 @@ export interface LLMRule {
 
   description?: string;
 
-  severity_rules?: BodyguardSeverityRule[];
+  severity_rules?: Array<BodyguardSeverityRule>;
 }
 
 export interface LabelResponse {
   name: string;
 
-  harm_labels?: string[];
+  harm_labels?: Array<string>;
 
-  phrase_list_ids?: number[];
+  phrase_list_ids?: Array<number>;
 }
 
 export interface LabelResultResponse {
@@ -14649,7 +14704,7 @@ export interface LabelResultResponse {
   /**
    * Moderation labels
    */
-  labels: string[];
+  labels: Array<string>;
 
   /**
    * Customer-supplied identifier for the moderated content
@@ -14775,7 +14830,7 @@ export interface LabelsResponse {
   /**
    * Moderation labels detected
    */
-  labels?: string[];
+  labels?: Array<string>;
 }
 
 export interface LayoutSettings {
@@ -14832,7 +14887,7 @@ export interface LimitInfoResponse {
 }
 
 export interface LimitsSettings {
-  max_participants_exclude_roles: string[];
+  max_participants_exclude_roles: Array<string>;
 
   max_duration_seconds?: number;
 
@@ -14848,11 +14903,11 @@ export interface LimitsSettingsRequest {
 
   max_participants_exclude_owner?: boolean;
 
-  max_participants_exclude_roles?: string[];
+  max_participants_exclude_roles?: Array<string>;
 }
 
 export interface LimitsSettingsResponse {
-  max_participants_exclude_roles: string[];
+  max_participants_exclude_roles: Array<string>;
 
   max_duration_seconds?: number;
 
@@ -14867,7 +14922,7 @@ export interface ListBlockListResponse {
    */
   duration: string;
 
-  blocklists: BlockListResponse[];
+  blocklists: Array<BlockListResponse>;
 
   next_cursor?: string;
 }
@@ -14893,7 +14948,7 @@ export interface ListCommandsResponse {
   /**
    * List of commands
    */
-  commands: Command[];
+  commands: Array<Command>;
 }
 
 export interface ListDevicesResponse {
@@ -14902,7 +14957,7 @@ export interface ListDevicesResponse {
   /**
    * List of devices
    */
-  devices: DeviceResponse[];
+  devices: Array<DeviceResponse>;
 }
 
 export interface ListExternalStorageResponse {
@@ -14947,7 +15002,7 @@ export interface ListImportV2TasksResponse {
    */
   duration: string;
 
-  import_tasks: ImportV2TaskItem[];
+  import_tasks: Array<ImportV2TaskItem>;
 
   next?: string;
 
@@ -14960,7 +15015,7 @@ export interface ListImportsResponse {
    */
   duration: string;
 
-  import_tasks: ImportTask[];
+  import_tasks: Array<ImportTask>;
 }
 
 export interface ListPermissionsResponse {
@@ -14969,7 +15024,7 @@ export interface ListPermissionsResponse {
    */
   duration: string;
 
-  permissions: Permission[];
+  permissions: Array<Permission>;
 }
 
 export interface ListPushProvidersResponse {
@@ -14978,7 +15033,7 @@ export interface ListPushProvidersResponse {
    */
   duration: string;
 
-  push_providers: PushProviderResponse[];
+  push_providers: Array<PushProviderResponse>;
 }
 
 export interface ListQueuesResponse {
@@ -14987,13 +15042,13 @@ export interface ListQueuesResponse {
    */
   duration: string;
 
-  queues: ModerationQueueResponse[];
+  queues: Array<ModerationQueueResponse>;
 }
 
 export interface ListRecordingsResponse {
   duration: string;
 
-  recordings: CallRecording[];
+  recordings: Array<CallRecording>;
 }
 
 export interface ListRolesResponse {
@@ -15002,7 +15057,7 @@ export interface ListRolesResponse {
    */
   duration: string;
 
-  roles: Role[];
+  roles: Array<Role>;
 }
 
 export interface ListSIPInboundRoutingRuleResponse {
@@ -15011,7 +15066,7 @@ export interface ListSIPInboundRoutingRuleResponse {
   /**
    * List of SIP Inbound Routing Rules for the application
    */
-  sip_inbound_routing_rules: SIPInboundRoutingRuleResponse[];
+  sip_inbound_routing_rules: Array<SIPInboundRoutingRuleResponse>;
 }
 
 export interface ListSIPTrunksResponse {
@@ -15020,7 +15075,7 @@ export interface ListSIPTrunksResponse {
   /**
    * List of SIP trunks for the application
    */
-  sip_trunks: SIPTrunkResponse[];
+  sip_trunks: Array<SIPTrunkResponse>;
 }
 
 export interface ListTranscriptionsResponse {
@@ -15029,7 +15084,7 @@ export interface ListTranscriptionsResponse {
   /**
    * List of transcriptions for the call
    */
-  transcriptions: CallTranscription[];
+  transcriptions: Array<CallTranscription>;
 }
 
 export interface ListUserGroupsResponse {
@@ -15038,7 +15093,7 @@ export interface ListUserGroupsResponse {
   /**
    * List of user groups
    */
-  user_groups: UserGroupResponse[];
+  user_groups: Array<UserGroupResponse>;
 }
 
 export interface Location {
@@ -15086,17 +15141,17 @@ export interface MarkActivityRequest {
   /**
    * List of activity IDs to mark as read
    */
-  mark_read?: string[];
+  mark_read?: Array<string>;
 
   /**
    * List of activity IDs to mark as seen
    */
-  mark_seen?: string[];
+  mark_seen?: Array<string>;
 
   /**
    * List of activity IDs to mark as watched (for stories)
    */
-  mark_watched?: string[];
+  mark_watched?: Array<string>;
 
   /**
    * User request object
@@ -15119,7 +15174,7 @@ export interface MarkChannelsReadRequest {
 }
 
 export interface MarkDeliveredRequest {
-  latest_delivered_messages?: DeliveredMessagePayload[];
+  latest_delivered_messages?: Array<DeliveredMessagePayload>;
 }
 
 export interface MarkDeliveredResponse {
@@ -15256,12 +15311,12 @@ export interface MatchedContent {
   /**
    * Image-classification entries (keyframe rule, Type=image) carry nested L1 → L2 classifications. Text entries (closed_caption rule, Type=text) carry flat label + severity. Resolved against the app's effective taxonomy on the image side.
    */
-  classifications?: Classification[];
+  classifications?: Array<Classification>;
 
   /**
    * OCR entries only (keyframe_ocr rule, Type=image). Bodyguard labels that fired against the keyframe's OCR-extracted text (e.g. `INSULT`, `HATE_SPEECH`). Distinct from `classifications` so consumers can route OCR matches separately from image-classification matches.
    */
-  ocr_classifications?: Classification[];
+  ocr_classifications?: Array<Classification>;
 }
 
 export interface MaxStreakChangedEvent {
@@ -15496,7 +15551,7 @@ export interface MembersResponse {
   /**
    * List of found members
    */
-  members: ChannelMemberResponse[];
+  members: Array<ChannelMemberResponse>;
 }
 
 export interface MembershipLevelResponse {
@@ -15528,7 +15583,7 @@ export interface MembershipLevelResponse {
   /**
    * Activity tags this membership level gives access to
    */
-  tags: string[];
+  tags: Array<string>;
 
   /**
    * Description of the membership level
@@ -15784,7 +15839,7 @@ export interface MessageHistoryEntryResponse {
 
   text: string;
 
-  attachments: Attachment[];
+  attachments: Array<Attachment>;
 
   custom: Record<string, any>;
 }
@@ -15917,7 +15972,7 @@ export interface MessageNewEvent {
   /**
    * The participants of the thread
    */
-  thread_participants?: UserResponseCommonFields[];
+  thread_participants?: Array<UserResponseCommonFields>;
 
   /**
    * Represents channel in chat
@@ -15934,7 +15989,7 @@ export interface MessageNewEvent {
 export interface MessageOptions {
   include_thread_participants?: boolean;
 
-  member_custom_include?: string[];
+  member_custom_include?: Array<string>;
 }
 
 export interface MessagePaginationParams {
@@ -16129,24 +16184,24 @@ export interface MessageRequest {
   /**
    * Array of message attachments
    */
-  attachments?: Attachment[];
+  attachments?: Array<Attachment>;
 
   /**
    * List of user group IDs to mention. Group members who are also channel members will receive push notifications. Max 10 groups
    */
-  mentioned_group_ids?: string[];
+  mentioned_group_ids?: Array<string>;
 
-  mentioned_roles?: string[];
+  mentioned_roles?: Array<string>;
 
   /**
    * Array of user IDs to mention
    */
-  mentioned_users?: string[];
+  mentioned_users?: Array<string>;
 
   /**
    * A list of user ids that have restricted visibility to the message
    */
-  restricted_visibility?: string[];
+  restricted_visibility?: Array<string>;
 
   custom?: Record<string, any>;
 
@@ -16229,27 +16284,27 @@ export interface MessageResponse {
   /**
    * Array of message attachments
    */
-  attachments: Attachment[];
+  attachments: Array<Attachment>;
 
   /**
    * List of 10 latest reactions to this message
    */
-  latest_reactions: ReactionResponse[];
+  latest_reactions: Array<ReactionResponse>;
 
   /**
    * List of mentioned users
    */
-  mentioned_users: UserResponse[];
+  mentioned_users: Array<UserResponse>;
 
   /**
    * List of 10 latest reactions of authenticated user to this message
    */
-  own_reactions: ReactionResponse[];
+  own_reactions: Array<ReactionResponse>;
 
   /**
    * A list of user ids that have restricted visibility to the message, if the list is not empty, the message is only visible to the users in the list
    */
-  restricted_visibility: string[];
+  restricted_visibility: Array<string>;
 
   custom: Record<string, any>;
 
@@ -16317,22 +16372,22 @@ export interface MessageResponse {
   /**
    * List of user group IDs mentioned in the message. Group members who are also channel members will receive push notifications based on their push preferences. Max 10 groups
    */
-  mentioned_group_ids?: string[];
+  mentioned_group_ids?: Array<string>;
 
   /**
    * List of mentioned user group objects.
    */
-  mentioned_groups?: UserGroupResponse[];
+  mentioned_groups?: Array<UserGroupResponse>;
 
   /**
    * List of roles mentioned in the message (e.g. admin, channel_moderator, custom roles). Members with matching roles will receive push notifications based on their push preferences. Max 10 roles
    */
-  mentioned_roles?: string[];
+  mentioned_roles?: Array<string>;
 
   /**
    * List of users who participate in thread
    */
-  thread_participants?: UserResponse[];
+  thread_participants?: Array<UserResponse>;
 
   draft?: DraftResponse;
 
@@ -16344,7 +16399,7 @@ export interface MessageResponse {
   /**
    * Contains image moderation information
    */
-  image_labels?: Record<string, string[]>;
+  image_labels?: Record<string, Array<string>>;
 
   member?: ChannelMemberPartialResponse;
 
@@ -16370,7 +16425,7 @@ export interface MessageResponse {
 }
 
 export interface MessageStatsResponse {
-  count_over_time?: CountByMinuteResponse[];
+  count_over_time?: Array<CountByMinuteResponse>;
 }
 
 export interface MessageUnblockedEvent {
@@ -16594,27 +16649,27 @@ export interface MessageWithChannelResponse {
   /**
    * Array of message attachments
    */
-  attachments: Attachment[];
+  attachments: Array<Attachment>;
 
   /**
    * List of 10 latest reactions to this message
    */
-  latest_reactions: ReactionResponse[];
+  latest_reactions: Array<ReactionResponse>;
 
   /**
    * List of mentioned users
    */
-  mentioned_users: UserResponse[];
+  mentioned_users: Array<UserResponse>;
 
   /**
    * List of 10 latest reactions of authenticated user to this message
    */
-  own_reactions: ReactionResponse[];
+  own_reactions: Array<ReactionResponse>;
 
   /**
    * A list of user ids that have restricted visibility to the message, if the list is not empty, the message is only visible to the users in the list
    */
-  restricted_visibility: string[];
+  restricted_visibility: Array<string>;
 
   /**
    * Represents channel in chat
@@ -16687,22 +16742,22 @@ export interface MessageWithChannelResponse {
   /**
    * List of user group IDs mentioned in the message. Group members who are also channel members will receive push notifications based on their push preferences. Max 10 groups
    */
-  mentioned_group_ids?: string[];
+  mentioned_group_ids?: Array<string>;
 
   /**
    * List of mentioned user group objects.
    */
-  mentioned_groups?: UserGroupResponse[];
+  mentioned_groups?: Array<UserGroupResponse>;
 
   /**
    * List of roles mentioned in the message (e.g. admin, channel_moderator, custom roles). Members with matching roles will receive push notifications based on their push preferences. Max 10 roles
    */
-  mentioned_roles?: string[];
+  mentioned_roles?: Array<string>;
 
   /**
    * List of users who participate in thread
    */
-  thread_participants?: UserResponse[];
+  thread_participants?: Array<UserResponse>;
 
   draft?: DraftResponse;
 
@@ -16714,7 +16769,7 @@ export interface MessageWithChannelResponse {
   /**
    * Contains image moderation information
    */
-  image_labels?: Record<string, string[]>;
+  image_labels?: Record<string, Array<string>>;
 
   member?: ChannelMemberPartialResponse;
 
@@ -16756,7 +16811,7 @@ export interface MetricStats {
   /**
    * Per-day values (only present in daily mode)
    */
-  daily?: DailyValue[];
+  daily?: Array<DailyValue>;
 }
 
 export interface MetricThreshold {
@@ -16772,7 +16827,7 @@ export interface MetricThreshold {
 }
 
 export interface MetricTimeSeries {
-  data_points?: number[][];
+  data_points?: Array<Array<number>>;
 }
 
 export interface MetricsPct {
@@ -16891,7 +16946,7 @@ export interface ModerationCallResponse {
 
   updated_at: Date;
 
-  blocked_user_ids: string[];
+  blocked_user_ids: Array<string>;
 
   custom: Record<string, any>;
 
@@ -16954,7 +17009,7 @@ export interface ModerationConfig {
 
   updated_at?: Date;
 
-  supported_video_call_harm_types?: string[];
+  supported_video_call_harm_types?: Array<string>;
 
   ai_image_config?: AIImageConfig;
 
@@ -17029,11 +17084,11 @@ export interface ModerationDashboardPreferences {
 
   media_queue_blur_enabled?: boolean;
 
-  allowed_moderation_action_reasons?: string[];
+  allowed_moderation_action_reasons?: Array<string>;
 
-  escalation_reasons?: string[];
+  escalation_reasons?: Array<string>;
 
-  filterable_custom_keys?: string[];
+  filterable_custom_keys?: Array<string>;
 
   keyframe_classifications_map?: Record<string, Record<string, boolean>>;
 
@@ -17061,7 +17116,7 @@ export interface ModerationFlagResponse {
 
   review_queue_item_id?: string;
 
-  labels?: string[];
+  labels?: Array<string>;
 
   custom?: Record<string, any>;
 
@@ -17164,17 +17219,19 @@ export interface ModerationMarkReviewedEvent {
 }
 
 export interface ModerationPayload {
-  audios?: string[];
+  audios?: Array<string>;
 
-  image_ordered_keys?: string[];
+  image_ordered_keys?: Array<string>;
 
-  images?: string[];
+  images?: Array<string>;
 
-  text_ordered_keys?: string[];
+  other_media?: Array<string>;
 
-  texts?: string[];
+  text_ordered_keys?: Array<string>;
 
-  videos?: string[];
+  texts?: Array<string>;
+
+  videos?: Array<string>;
 
   custom?: Record<string, any>;
 
@@ -17187,22 +17244,22 @@ export interface ModerationPayloadRequest {
   /**
    * Audio URLs to moderate
    */
-  audios?: string[];
+  audios?: Array<string>;
 
   /**
    * Image URLs to moderate (max 30)
    */
-  images?: string[];
+  images?: Array<string>;
 
   /**
    * Text content to moderate
    */
-  texts?: string[];
+  texts?: Array<string>;
 
   /**
    * Video URLs to moderate
    */
-  videos?: string[];
+  videos?: Array<string>;
 
   /**
    * Custom data for moderation
@@ -17214,32 +17271,37 @@ export interface ModerationPayloadResponse {
   /**
    * Audio URLs to moderate
    */
-  audios?: string[];
+  audios?: Array<string>;
 
   /**
    * Caller-supplied keys for images, index-aligned with images[]
    */
-  image_ordered_keys?: string[];
+  image_ordered_keys?: Array<string>;
 
   /**
    * Image URLs to moderate
    */
-  images?: string[];
+  images?: Array<string>;
+
+  /**
+   * Media URLs from attachments outside the typed image/video/audio lists (custom attachment types such as GIF pickers)
+   */
+  other_media?: Array<string>;
 
   /**
    * Caller-supplied keys for texts (e.g. "title", "description"), index-aligned with texts[]
    */
-  text_ordered_keys?: string[];
+  text_ordered_keys?: Array<string>;
 
   /**
    * Text content to moderate
    */
-  texts?: string[];
+  texts?: Array<string>;
 
   /**
    * Video URLs to moderate
    */
-  videos?: string[];
+  videos?: Array<string>;
 
   /**
    * Custom data for moderation
@@ -17316,17 +17378,17 @@ export interface ModerationRuleV2Response {
 
   updated_at: Date;
 
-  config_keys: string[];
+  config_keys: Array<string>;
 
   cooldown_period?: string;
 
   logic?: string;
 
-  action_sequences?: CallRuleActionSequence[];
+  action_sequences?: Array<CallRuleActionSequence>;
 
-  conditions?: RuleBuilderCondition[];
+  conditions?: Array<RuleBuilderCondition>;
 
-  groups?: RuleBuilderConditionGroup[];
+  groups?: Array<RuleBuilderConditionGroup>;
 
   action?: RuleBuilderAction;
 }
@@ -17352,7 +17414,7 @@ export interface ModerationRulesTriggeredEvent {
   /**
    * Array of action types that were triggered
    */
-  triggered_actions: string[];
+  triggered_actions: Array<string>;
 
   custom: Record<string, any>;
 
@@ -17375,7 +17437,7 @@ export interface ModerationRulesTriggeredEvent {
   /**
    * Ordered list of contents whose verdicts contributed to an aggregation rule's threshold. Populated only for aggregation rules when callers supplied `content_ids`.
    */
-  matched_contents?: MatchedContent[];
+  matched_contents?: Array<MatchedContent>;
 }
 
 export interface ModerationTextAnalysisCompleteEvent {
@@ -17432,11 +17494,11 @@ export interface ModerationV2Response {
 
   semantic_filter_matched?: string;
 
-  blocklists_matched?: string[];
+  blocklists_matched?: Array<string>;
 
-  image_harms?: string[];
+  image_harms?: Array<string>;
 
-  text_harms?: string[];
+  text_harms?: Array<string>;
 }
 
 export interface MuteChannelRequest {
@@ -17450,7 +17512,7 @@ export interface MuteChannelRequest {
   /**
    * Channel CIDs to mute (if multiple channels)
    */
-  channel_cids?: string[];
+  channel_cids?: Array<string>;
 
   /**
    * User request object
@@ -17464,7 +17526,7 @@ export interface MuteChannelResponse {
   /**
    * Object with mutes (if multiple channels were muted)
    */
-  channel_mutes?: ChannelMute[];
+  channel_mutes?: Array<ChannelMute>;
 
   channel_mute?: ChannelMute;
 
@@ -17475,7 +17537,7 @@ export interface MuteRequest {
   /**
    * User IDs to mute (if multiple users)
    */
-  target_ids: string[];
+  target_ids: Array<string>;
 
   /**
    * Duration of mute in minutes
@@ -17496,12 +17558,12 @@ export interface MuteResponse {
   /**
    * Object with mutes (if multiple users were muted)
    */
-  mutes?: UserMuteResponse[];
+  mutes?: Array<UserMuteResponse>;
 
   /**
    * A list of users that can't be found. Common cause for this is deleted users
    */
-  non_existing_users?: string[];
+  non_existing_users?: Array<string>;
 
   own_user?: OwnUserResponse;
 }
@@ -17519,7 +17581,7 @@ export interface MuteUsersRequest {
 
   video?: boolean;
 
-  user_ids?: string[];
+  user_ids?: Array<string>;
 
   /**
    * User request object
@@ -17555,7 +17617,7 @@ export interface NotificationComment {
 
   user_id: string;
 
-  attachments?: Attachment[];
+  attachments?: Array<Attachment>;
 }
 
 export interface NotificationConfig {
@@ -17606,7 +17668,7 @@ export interface NotificationFeedUpdatedEvent {
   /**
    * Aggregated activities for notification feeds
    */
-  aggregated_activities?: AggregatedActivityResponse[];
+  aggregated_activities?: Array<AggregatedActivityResponse>;
 
   notification_status?: NotificationStatusResponse;
 
@@ -17726,7 +17788,7 @@ export interface NotificationParentActivity {
 
   user_id?: string;
 
-  attachments?: Attachment[];
+  attachments?: Array<Attachment>;
 }
 
 export interface NotificationSettings {
@@ -17795,12 +17857,12 @@ export interface NotificationStatusResponse {
   /**
    * Deprecated: use is_read on each activity/group instead. IDs of activities that have been read. Capped at ~101 entries for aggregated feeds.
    */
-  read_activities?: string[];
+  read_activities?: Array<string>;
 
   /**
    * Deprecated: use is_seen on each activity/group instead. IDs of activities that have been seen. Capped at ~101 entries for aggregated feeds.
    */
-  seen_activities?: string[];
+  seen_activities?: Array<string>;
 }
 
 export interface NotificationTarget {
@@ -17832,7 +17894,7 @@ export interface NotificationTarget {
   /**
    * Attachments on the target activity (for activity targets)
    */
-  attachments?: Attachment[];
+  attachments?: Array<Attachment>;
 
   comment?: NotificationComment;
 
@@ -17914,7 +17976,7 @@ export interface NotificationThreadMessageNewEvent {
   /**
    * The participants of the thread
    */
-  thread_participants?: UserResponseCommonFields[];
+  thread_participants?: Array<UserResponseCommonFields>;
 
   channel_custom?: Record<string, any>;
 }
@@ -17943,7 +18005,7 @@ export interface OCRContentParameters {
 
   severity?: string;
 
-  harm_labels?: string[];
+  harm_labels?: Array<string>;
 }
 
 export interface OCRRule {
@@ -17960,21 +18022,21 @@ export interface OnlyUserID {
 export interface OverviewDashboardConfig {
   default_date_range_days?: number;
 
-  visible_charts?: string[];
+  visible_charts?: Array<string>;
 }
 
 export interface OwnBatchRequest {
   /**
    * List of feed IDs to get own fields for
    */
-  feeds: string[];
+  feeds: Array<string>;
 
   user_id?: string;
 
   /**
    * Optional list of specific fields to return. If not specified, all fields (own_follows, own_followings, own_capabilities, own_membership) are returned
    */
-  fields?: string[];
+  fields?: Array<string>;
 
   /**
    * User request object
@@ -18057,13 +18119,13 @@ export interface OwnUserResponse {
 
   updated_at: Date;
 
-  channel_mutes: ChannelMute[];
+  channel_mutes: Array<ChannelMute>;
 
-  devices: DeviceResponse[];
+  devices: Array<DeviceResponse>;
 
-  mutes: UserMuteResponse[];
+  mutes: Array<UserMuteResponse>;
 
-  teams: string[];
+  teams: Array<string>;
 
   custom: Record<string, any>;
 
@@ -18081,9 +18143,9 @@ export interface OwnUserResponse {
 
   revoke_tokens_issued_before?: Date;
 
-  blocked_user_ids?: string[];
+  blocked_user_ids?: Array<string>;
 
-  latest_hidden_channels?: string[];
+  latest_hidden_channels?: Array<string>;
 
   privacy_settings?: PrivacySettingsResponse;
 
@@ -18119,7 +18181,7 @@ export interface ParsedPredefinedFilterResponse {
 
   filter: Record<string, any>;
 
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 }
 
 export interface ParticipantCountByMinuteResponse {
@@ -18135,7 +18197,7 @@ export interface ParticipantCountByMinuteResponse {
 }
 
 export interface ParticipantCountOverTimeResponse {
-  by_minute?: ParticipantCountByMinuteResponse[];
+  by_minute?: Array<ParticipantCountByMinuteResponse>;
 }
 
 export interface ParticipantReportResponse {
@@ -18145,13 +18207,13 @@ export interface ParticipantReportResponse {
 
   max_concurrent?: number;
 
-  by_browser?: GroupedStatsResponse[];
+  by_browser?: Array<GroupedStatsResponse>;
 
-  by_country?: GroupedStatsResponse[];
+  by_country?: Array<GroupedStatsResponse>;
 
-  by_device?: GroupedStatsResponse[];
+  by_device?: Array<GroupedStatsResponse>;
 
-  by_operating_system?: GroupedStatsResponse[];
+  by_operating_system?: Array<GroupedStatsResponse>;
 
   count_over_time?: ParticipantCountOverTimeResponse;
 
@@ -18161,27 +18223,27 @@ export interface ParticipantReportResponse {
 }
 
 export interface ParticipantSeriesPublisherStats {
-  global_metrics_order?: string[];
+  global_metrics_order?: Array<string>;
 
-  global?: Record<string, number[][]>;
+  global?: Record<string, Array<Array<number>>>;
 
   global_meta?: Record<string, MetricDescriptor>;
 
-  global_thresholds?: Record<string, MetricThreshold[]>;
+  global_thresholds?: Record<string, Array<MetricThreshold>>;
 
-  tracks?: Record<string, ParticipantSeriesTrackMetrics[]>;
+  tracks?: Record<string, Array<ParticipantSeriesTrackMetrics>>;
 }
 
 export interface ParticipantSeriesSubscriberStats {
-  global_metrics_order?: string[];
+  global_metrics_order?: Array<string>;
 
-  subscriptions?: ParticipantSeriesSubscriptionTrackMetrics[];
+  subscriptions?: Array<ParticipantSeriesSubscriptionTrackMetrics>;
 
-  global?: Record<string, number[][]>;
+  global?: Record<string, Array<Array<number>>>;
 
   global_meta?: Record<string, MetricDescriptor>;
 
-  global_thresholds?: Record<string, MetricThreshold[]>;
+  global_thresholds?: Record<string, Array<MetricThreshold>>;
 }
 
 export interface ParticipantSeriesSubscriptionTrackMetrics {
@@ -18191,7 +18253,7 @@ export interface ParticipantSeriesSubscriptionTrackMetrics {
 
   publisher_user_session_id?: string;
 
-  tracks?: Record<string, ParticipantSeriesTrackMetrics[]>;
+  tracks?: Record<string, Array<ParticipantSeriesTrackMetrics>>;
 }
 
 export interface ParticipantSeriesTimeframe {
@@ -18215,23 +18277,23 @@ export interface ParticipantSeriesTrackMetrics {
 
   track_type?: string;
 
-  metrics_order?: string[];
+  metrics_order?: Array<string>;
 
-  metrics?: Record<string, number[][]>;
+  metrics?: Record<string, Array<Array<number>>>;
 
   metrics_meta?: Record<string, MetricDescriptor>;
 
-  thresholds?: Record<string, MetricThreshold[]>;
+  thresholds?: Record<string, Array<MetricThreshold>>;
 }
 
 export interface ParticipantSeriesUserStats {
-  metrics_order?: string[];
+  metrics_order?: Array<string>;
 
-  metrics?: Record<string, number[][]>;
+  metrics?: Record<string, Array<Array<number>>>;
 
   metrics_meta?: Record<string, MetricDescriptor>;
 
-  thresholds?: Record<string, MetricThreshold[]>;
+  thresholds?: Record<string, Array<MetricThreshold>>;
 }
 
 export interface ParticipantSessionDetails {
@@ -18241,7 +18303,7 @@ export interface ParticipantSessionDetails {
 
   user_session_id: string;
 
-  roles: string[];
+  roles: Array<string>;
 
   duration_in_seconds?: number;
 
@@ -18322,6 +18384,26 @@ export interface Percentiles {
   p95?: number;
 }
 
+export interface PerformanceAnalysisResponse {
+  analysis_type: string;
+
+  score: string;
+
+  indexed_fields: Array<string>;
+
+  recommendations: Array<string>;
+
+  unindexed_fields: Array<string>;
+
+  unindexed_sort_fields: Array<string>;
+
+  warnings: Array<string>;
+
+  last_analyzed?: Date;
+
+  scan_type?: string;
+}
+
 export interface Permission {
   /**
    * Action name this permission is for (e.g. SendMessage)
@@ -18371,7 +18453,39 @@ export interface Permission {
   /**
    * List of tags of the permission
    */
-  tags: string[];
+  tags: Array<string>;
+
+  /**
+   * MongoDB style condition which decides whether or not the permission is granted
+   */
+  condition?: Record<string, any>;
+}
+
+export interface PermissionRequest {
+  /**
+   * Action name this permission is for (e.g. SendMessage)
+   */
+  action: string;
+
+  /**
+   * Name of the permission
+   */
+  name: string;
+
+  /**
+   * Description of the permission
+   */
+  description?: string;
+
+  /**
+   * Whether this permission applies to resource owner or not
+   */
+  owner?: boolean;
+
+  /**
+   * Whether this permission applies to teammates (multi-tenancy mode only)
+   */
+  same_team?: boolean;
 
   /**
    * MongoDB style condition which decides whether or not the permission is granted
@@ -18387,7 +18501,7 @@ export interface PermissionRequestEvent {
   /**
    * The list of permissions requested by the user
    */
-  permissions: string[];
+  permissions: Array<string>;
 
   /**
    * User response object
@@ -18475,9 +18589,9 @@ export interface Policy {
 
   updated_at: Date;
 
-  resources: string[];
+  resources: Array<string>;
 
-  roles: string[];
+  roles: Array<string>;
 }
 
 export interface PolicyConfig {
@@ -18505,12 +18619,12 @@ export interface PolicyRequest {
   /**
    * List of resources to apply policy to
    */
-  resources: string[];
+  resources: Array<string>;
 
   /**
    * List of roles to apply policy to
    */
-  roles: string[];
+  roles: Array<string>;
 }
 
 export interface PolicyTestLabelDrift {
@@ -18542,9 +18656,9 @@ export interface PolicyTestResult {
 
   severity?: string;
 
-  actual_labels?: string[];
+  actual_labels?: Array<string>;
 
-  expected_labels?: string[];
+  expected_labels?: Array<string>;
 
   raw_response?: Record<string, any>;
 }
@@ -18558,7 +18672,7 @@ export interface PolicyTestRow {
 
   text?: string;
 
-  labels?: string[];
+  labels?: Array<string>;
 }
 
 export interface PolicyTestRun {
@@ -18605,7 +18719,7 @@ export interface PolicyTestRunResponse {
   /**
    * Per-row results (only present once the run has finished)
    */
-  results?: PolicyTestResult[];
+  results?: Array<PolicyTestResult>;
 
   run?: PolicyTestRun;
 }
@@ -18619,7 +18733,7 @@ export interface PolicyTestSeedSpec {
   /**
    * Sample only records carrying any of these labels; empty samples everything
    */
-  labels?: string[];
+  labels?: Array<string>;
 }
 
 export interface PolicyTestSet {
@@ -18641,7 +18755,7 @@ export interface PolicyTestSet {
 
   team?: string;
 
-  rows?: PolicyTestRow[];
+  rows?: Array<PolicyTestRow>;
 
   last_run?: PolicyTestRun;
 }
@@ -18652,7 +18766,7 @@ export interface PolicyTestSetListResponse {
   /**
    * List of policy test sets for the app
    */
-  sets: PolicyTestSet[];
+  sets: Array<PolicyTestSet>;
 }
 
 export interface PolicyTestSetResponse {
@@ -18666,7 +18780,7 @@ export interface PolicyTestSetResponse {
   /**
    * Retained run history for this set, newest first
    */
-  recent_runs?: PolicyTestRun[];
+  recent_runs?: Array<PolicyTestRun>;
 
   set?: PolicyTestSet;
 }
@@ -18748,15 +18862,15 @@ export interface PollResponseData {
 
   voting_visibility: string;
 
-  latest_answers: PollVoteResponseData[];
+  latest_answers: Array<PollVoteResponseData>;
 
-  options: PollOptionResponseData[];
+  options: Array<PollOptionResponseData>;
 
-  own_votes: PollVoteResponseData[];
+  own_votes: Array<PollVoteResponseData>;
 
   custom: Record<string, any>;
 
-  latest_votes_by_option: Record<string, PollVoteResponseData[]>;
+  latest_votes_by_option: Record<string, Array<PollVoteResponseData>>;
 
   vote_counts_by_option: Record<string, number>;
 
@@ -18813,7 +18927,7 @@ export interface PollVotesResponse {
   /**
    * Poll votes
    */
-  votes: PollVoteResponseData[];
+  votes: Array<PollVoteResponseData>;
 
   next?: string;
 
@@ -18846,6 +18960,36 @@ export interface PoorTail {
   healthy_pct?: number;
 }
 
+export interface PredefinedFilterResponse {
+  created_at: Date;
+
+  name: string;
+
+  operation: string;
+
+  updated_at: Date;
+
+  filter: Record<string, any>;
+
+  description?: string;
+
+  query_id?: number;
+
+  sort?: Array<SortParam>;
+
+  performance?: PerformanceAnalysisResponse;
+
+  stats?: PredefinedFilterStatsResponse;
+}
+
+export interface PredefinedFilterStatsResponse {
+  calls: number;
+
+  max_latency_ms: number;
+
+  last_seen?: Date;
+}
+
 export interface PrivacySettingsResponse {
   delivery_receipts?: DeliveryReceiptsResponse;
 
@@ -18871,7 +19015,7 @@ export interface PublishedTrackMetrics {
 
   track_type?: string;
 
-  warnings?: SessionWarningResponse[];
+  warnings?: Array<SessionWarningResponse>;
 
   bitrate?: MetricTimeSeries;
 
@@ -18923,7 +19067,7 @@ export interface PublisherStatsResponse {
 
   unique: number;
 
-  by_track?: TrackStatsResponse[];
+  by_track?: Array<TrackStatsResponse>;
 }
 
 export interface PublisherVideoMetrics {
@@ -18955,9 +19099,9 @@ export interface PushNotificationConfig {
   enable_push?: boolean;
 
   /**
-   * List of notification types that should trigger push notifications (e.g., follow, comment, reaction, comment_reaction, mention)
+   * Allowlist of notification types that may trigger push (e.g. follow, comment, reaction, comment_reaction, mention, or any custom activity.type). Empty or omitted means no types. Built-in notifications match notification_context.trigger.type; manually added notification activities match activity.type.
    */
-  push_types?: string[];
+  push_types?: Array<string>;
 }
 
 export interface PushNotificationFields {
@@ -18973,7 +19117,7 @@ export interface PushNotificationFields {
 
   xiaomi: XiaomiConfigFields;
 
-  providers?: PushProvider[];
+  providers?: Array<PushProvider>;
 }
 
 export interface PushNotificationSettingsResponse {
@@ -19101,7 +19245,7 @@ export interface PushProvider {
 
   xiaomi_package_name?: string;
 
-  push_templates?: PushTemplate[];
+  push_templates?: Array<PushTemplate>;
 }
 
 export interface PushProviderRequest {
@@ -19269,7 +19413,7 @@ export interface PushTemplateResponse {
 export interface Quality {
   viewer_interruption_note: string;
 
-  interruption_incidents: Incident[];
+  interruption_incidents: Array<Incident>;
 
   connection_avg_jitter_ms: Percentiles;
 
@@ -19287,11 +19431,11 @@ export interface Quality {
 }
 
 export interface QualityScoreReport {
-  histogram: ReportByHistogramBucket[];
+  histogram: Array<ReportByHistogramBucket>;
 }
 
 export interface QualityScoreReportResponse {
-  daily: DailyAggregateQualityScoreReportResponse[];
+  daily: Array<DailyAggregateQualityScoreReportResponse>;
 }
 
 export interface QueryActivitiesRequest {
@@ -19320,7 +19464,7 @@ export interface QueryActivitiesRequest {
   /**
    * Sorting parameters for the query
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filters to apply to the query. Supports location-based queries with 'near' and 'within_bounds' operators.
@@ -19339,7 +19483,7 @@ export interface QueryActivitiesResponse {
   /**
    * List of activities matching the query
    */
-  activities: ActivityResponse[];
+  activities: Array<ActivityResponse>;
 
   /**
    * Cursor for next page
@@ -19359,7 +19503,7 @@ export interface QueryActivityReactionsRequest {
 
   prev?: string;
 
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filters to apply to the query
@@ -19373,7 +19517,7 @@ export interface QueryActivityReactionsResponse {
    */
   duration: string;
 
-  reactions: FeedsReactionResponse[];
+  reactions: Array<FeedsReactionResponse>;
 
   next?: string;
 
@@ -19386,7 +19530,7 @@ export interface QueryActivitySharesResponse {
    */
   duration: string;
 
-  shares: ShareResponse[];
+  shares: Array<ShareResponse>;
 
   next?: string;
 
@@ -19398,7 +19542,7 @@ export interface QueryAggregateCallStatsRequest {
 
   to?: string;
 
-  report_types?: string[];
+  report_types?: Array<string>;
 }
 
 export interface QueryAggregateCallStatsResponse {
@@ -19434,7 +19578,7 @@ export interface QueryAppealsRequest {
   /**
    * Sorting parameters for appeals
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter conditions for appeals
@@ -19453,7 +19597,7 @@ export interface QueryAppealsResponse {
   /**
    * List of Appeal Items
    */
-  items: AppealItemResponse[];
+  items: Array<AppealItemResponse>;
 
   next?: string;
 
@@ -19486,7 +19630,7 @@ export interface QueryBannedUsersPayload {
   /**
    * Array of sort parameters
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * User request object
@@ -19503,7 +19647,7 @@ export interface QueryBannedUsersResponse {
   /**
    * List of found bans
    */
-  bans: BanResponse[];
+  bans: Array<BanResponse>;
 }
 
 export interface QueryBookmarkFoldersRequest {
@@ -19516,7 +19660,7 @@ export interface QueryBookmarkFoldersRequest {
   /**
    * Sorting parameters for the query
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filters to apply to the query
@@ -19530,7 +19674,7 @@ export interface QueryBookmarkFoldersResponse {
   /**
    * List of bookmark folders matching the query
    */
-  bookmark_folders: BookmarkFolderResponse[];
+  bookmark_folders: Array<BookmarkFolderResponse>;
 
   /**
    * Cursor for next page
@@ -19557,7 +19701,7 @@ export interface QueryBookmarksRequest {
   /**
    * Sorting parameters for the query
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filters to apply to the query
@@ -19576,7 +19720,7 @@ export interface QueryBookmarksResponse {
   /**
    * List of bookmarks matching the query
    */
-  bookmarks: BookmarkResponse[];
+  bookmarks: Array<BookmarkResponse>;
 
   /**
    * Cursor for next page
@@ -19603,7 +19747,7 @@ export interface QueryCallMembersRequest {
   /**
    * Array of sort parameters
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter conditions to apply to the query
@@ -19617,7 +19761,7 @@ export interface QueryCallMembersResponse {
    */
   duration: string;
 
-  members: MemberResponse[];
+  members: Array<MemberResponse>;
 
   next?: string;
 
@@ -19640,7 +19784,7 @@ export interface QueryCallParticipantSessionsResponse {
 
   total_participant_sessions: number;
 
-  participants_sessions: ParticipantSessionDetails[];
+  participants_sessions: Array<ParticipantSessionDetails>;
 
   next?: string;
 
@@ -19661,14 +19805,14 @@ export interface QueryCallParticipantsResponse {
 
   total_participants: number;
 
-  members: MemberResponse[];
+  members: Array<MemberResponse>;
 
-  own_capabilities: OwnCapability[];
+  own_capabilities: Array<OwnCapability>;
 
   /**
    * List of call participants
    */
-  participants: CallParticipantResponse[];
+  participants: Array<CallParticipantResponse>;
 
   /**
    * Represents a call
@@ -19688,7 +19832,7 @@ export interface QueryCallSessionParticipantStatsResponse {
    */
   duration: string;
 
-  participants: CallStatsParticipant[];
+  participants: Array<CallStatsParticipant>;
 
   counts: CallStatsParticipantCounts;
 
@@ -19702,7 +19846,7 @@ export interface QueryCallSessionParticipantStatsResponse {
 
   tmp_data_source?: string;
 
-  call_events?: CallLevelEventPayload[];
+  call_events?: Array<CallLevelEventPayload>;
 }
 
 export interface QueryCallSessionParticipantStatsTimelineResponse {
@@ -19721,7 +19865,7 @@ export interface QueryCallSessionParticipantStatsTimelineResponse {
 
   user_session_id: string;
 
-  events: CallParticipantTimeline[];
+  events: Array<CallParticipantTimeline>;
 }
 
 export interface QueryCallSessionStatsRequest {
@@ -19734,7 +19878,7 @@ export interface QueryCallSessionStatsRequest {
   /**
    * Array of sort parameters
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter conditions to apply to the query
@@ -19748,7 +19892,7 @@ export interface QueryCallSessionStatsResponse {
    */
   duration: string;
 
-  call_stats: CallStatsSessionResponse[];
+  call_stats: Array<CallStatsSessionResponse>;
 
   next?: string;
 
@@ -19798,7 +19942,7 @@ export interface QueryCallStatsRequest {
   /**
    * Array of sort parameters
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter conditions to apply to the query
@@ -19812,7 +19956,7 @@ export interface QueryCallStatsResponse {
    */
   duration: string;
 
-  reports: CallStatsReportSummaryResponse[];
+  reports: Array<CallStatsReportSummaryResponse>;
 
   next?: string;
 
@@ -19829,7 +19973,7 @@ export interface QueryCallsRequest {
   /**
    * Array of sort parameters
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter conditions to apply to the query
@@ -19843,7 +19987,7 @@ export interface QueryCallsResponse {
    */
   duration: string;
 
-  calls: CallStateResponseFields[];
+  calls: Array<CallStateResponseFields>;
 
   next?: string;
 
@@ -19859,7 +20003,7 @@ export interface QueryCampaignsRequest {
 
   user_limit?: number;
 
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter to apply to the query
@@ -19873,7 +20017,7 @@ export interface QueryCampaignsResponse {
    */
   duration: string;
 
-  campaigns: CampaignResponse[];
+  campaigns: Array<CampaignResponse>;
 
   next?: string;
 
@@ -19916,12 +20060,12 @@ export interface QueryChannelsRequest {
   /**
    * Top-level keys of the message sender's channel-member custom data to include under member.custom (max 8 keys, 64 chars each)
    */
-  member_custom_include?: string[];
+  member_custom_include?: Array<string>;
 
   /**
    * List of sort parameters
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter conditions to apply to the query
@@ -19950,7 +20094,7 @@ export interface QueryChannelsResponse {
   /**
    * List of channels
    */
-  channels: ChannelStateResponseFields[];
+  channels: Array<ChannelStateResponseFields>;
 
   predefined_filter?: ParsedPredefinedFilterResponse;
 }
@@ -19967,7 +20111,7 @@ export interface QueryCollectionsRequest {
   /**
    * Sorting parameters for the query
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filters to apply to the query
@@ -19986,7 +20130,7 @@ export interface QueryCollectionsResponse {
   /**
    * List of collections matching the query
    */
-  collections: CollectionResponse[];
+  collections: Array<CollectionResponse>;
 
   /**
    * Cursor for next page
@@ -20006,7 +20150,7 @@ export interface QueryCommentReactionsRequest {
 
   prev?: string;
 
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filters to apply to the query
@@ -20020,7 +20164,7 @@ export interface QueryCommentReactionsResponse {
    */
   duration: string;
 
-  reactions: FeedsReactionResponse[];
+  reactions: Array<FeedsReactionResponse>;
 
   next?: string;
 
@@ -20067,7 +20211,7 @@ export interface QueryCommentsResponse {
   /**
    * List of comments matching the query
    */
-  comments: CommentResponse[];
+  comments: Array<CommentResponse>;
 
   /**
    * Cursor for next page
@@ -20092,7 +20236,7 @@ export interface QueryDraftsRequest {
   /**
    * Array of sort parameters
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter to apply to the query
@@ -20114,7 +20258,7 @@ export interface QueryDraftsResponse {
   /**
    * Drafts
    */
-  drafts: DraftResponse[];
+  drafts: Array<DraftResponse>;
 
   next?: string;
 
@@ -20131,7 +20275,7 @@ export interface QueryFeedMembersRequest {
   /**
    * Sort parameters for the query
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter parameters for the query
@@ -20145,7 +20289,7 @@ export interface QueryFeedMembersResponse {
   /**
    * List of feed members
    */
-  members: FeedMemberResponse[];
+  members: Array<FeedMemberResponse>;
 
   /**
    * Cursor for next page
@@ -20186,7 +20330,7 @@ export interface QueryFeedModerationTemplatesResponse {
   /**
    * List of moderation templates
    */
-  templates: QueryFeedModerationTemplate[];
+  templates: Array<QueryFeedModerationTemplate>;
 }
 
 export interface QueryFeedsRequest {
@@ -20206,7 +20350,7 @@ export interface QueryFeedsRequest {
   /**
    * Sorting parameters for the query
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filters to apply to the query
@@ -20220,7 +20364,7 @@ export interface QueryFeedsResponse {
   /**
    * List of feeds matching the query
    */
-  feeds: FeedResponse[];
+  feeds: Array<FeedResponse>;
 
   /**
    * Cursor for next page
@@ -20269,7 +20413,7 @@ export interface QueryFollowsRequest {
   /**
    * Sorting parameters for the query
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filters to apply to the query
@@ -20283,7 +20427,7 @@ export interface QueryFollowsResponse {
   /**
    * List of follow relationships matching the query
    */
-  follows: FollowResponse[];
+  follows: Array<FollowResponse>;
 
   /**
    * Cursor for next page
@@ -20339,7 +20483,7 @@ export interface QueryFutureChannelBansResponse {
   /**
    * List of found future channel bans
    */
-  bans: FutureChannelBanResponse[];
+  bans: Array<FutureChannelBanResponse>;
 
   /**
    * Total number of bans matching the query filter, computed at query time and capped at 100000. Only present when include_total is set on the request; omitted when computing the total timed out
@@ -20359,7 +20503,7 @@ export interface QueryLabelResultsRequest {
   /**
    * Sorting parameters
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter conditions
@@ -20378,7 +20522,7 @@ export interface QueryLabelResultsResponse {
   /**
    * List of moderation label results
    */
-  label_results: LabelResultResponse[];
+  label_results: Array<LabelResultResponse>;
 
   next?: string;
 
@@ -20401,12 +20545,12 @@ export interface QueryMembersPayload {
 
   user_id?: string;
 
-  members?: ChannelMemberRequest[];
+  members?: Array<ChannelMemberRequest>;
 
   /**
    * Array of sort parameters
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * User request object
@@ -20424,7 +20568,7 @@ export interface QueryMembershipLevelsRequest {
   /**
    * Sorting parameters for the query
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filters to apply to the query
@@ -20435,7 +20579,7 @@ export interface QueryMembershipLevelsRequest {
 export interface QueryMembershipLevelsResponse {
   duration: string;
 
-  membership_levels: MembershipLevelResponse[];
+  membership_levels: Array<MembershipLevelResponse>;
 
   /**
    * Cursor for next page
@@ -20463,7 +20607,7 @@ export interface QueryMessageFlagsPayload {
   /**
    * Array of sort parameters
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter conditions to apply to the query
@@ -20485,7 +20629,7 @@ export interface QueryMessageFlagsResponse {
   /**
    * The flags that match the query
    */
-  flags: MessageFlagResponse[];
+  flags: Array<MessageFlagResponse>;
 }
 
 export interface QueryMessageHistoryRequest {
@@ -20503,7 +20647,7 @@ export interface QueryMessageHistoryRequest {
   /**
    * Array of sort parameters
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 }
 
 export interface QueryMessageHistoryResponse {
@@ -20515,7 +20659,7 @@ export interface QueryMessageHistoryResponse {
   /**
    * Message history entries
    */
-  message_history: MessageHistoryEntryResponse[];
+  message_history: Array<MessageHistoryEntryResponse>;
 
   next?: string;
 
@@ -20534,7 +20678,7 @@ export interface QueryModerationConfigsRequest {
   /**
    * Sorting parameters for the results
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter conditions for moderation configs
@@ -20553,7 +20697,7 @@ export interface QueryModerationConfigsResponse {
   /**
    * List of moderation configurations
    */
-  configs: ConfigResponse[];
+  configs: Array<ConfigResponse>;
 
   next?: string;
 
@@ -20567,7 +20711,7 @@ export interface QueryModerationFlagsRequest {
 
   prev?: string;
 
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter conditions for moderation flags
@@ -20581,7 +20725,7 @@ export interface QueryModerationFlagsResponse {
    */
   duration: string;
 
-  flags: ModerationFlagResponse[];
+  flags: Array<ModerationFlagResponse>;
 
   next?: string;
 
@@ -20600,7 +20744,7 @@ export interface QueryModerationLogsRequest {
   /**
    * Sorting parameters for the results
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter conditions for moderation logs
@@ -20619,7 +20763,7 @@ export interface QueryModerationLogsResponse {
   /**
    * List of moderation action logs
    */
-  logs: ActionLogResponse[];
+  logs: Array<ActionLogResponse>;
 
   next?: string;
 
@@ -20638,7 +20782,7 @@ export interface QueryModerationRulesRequest {
   /**
    * Sorting parameters for the results
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter conditions for moderation rules
@@ -20657,32 +20801,32 @@ export interface QueryModerationRulesResponse {
   /**
    * AI image label definitions with metadata for dashboard rendering
    */
-  ai_image_label_definitions: AIImageLabelDefinition[];
+  ai_image_label_definitions: Array<AIImageLabelDefinition>;
 
   /**
    * Available harm labels for closed caption rules
    */
-  closed_caption_labels: string[];
+  closed_caption_labels: Array<string>;
 
   /**
    * Deprecated: use keyframe_label_classifications instead. Available L1 harm labels for keyframe rules
    */
-  keyframe_labels: string[];
+  keyframe_labels: Array<string>;
 
   /**
    * Available harm labels for OCR-based rule conditions (keyframe_ocr_rule and ocr_content). Mirrors `closed_caption_labels` today but kept as a separate field so the pickers can diverge later.
    */
-  ocr_labels: string[];
+  ocr_labels: Array<string>;
 
   /**
    * List of moderation rules
    */
-  rules: ModerationRuleV2Response[];
+  rules: Array<ModerationRuleV2Response>;
 
   /**
    * Stream L1 to leaf-level label name mapping for AI image rules
    */
-  ai_image_subclassifications: Record<string, string[]>;
+  ai_image_subclassifications: Record<string, Array<string>>;
 
   /**
    * Default LLM label descriptions
@@ -20697,7 +20841,7 @@ export interface QueryModerationRulesResponse {
   /**
    * L1 to L2 mapping of keyframe harm label classifications
    */
-  keyframe_label_classifications: Record<string, string[]>;
+  keyframe_label_classifications: Record<string, Array<string>>;
 
   next?: string;
 
@@ -20716,7 +20860,7 @@ export interface QueryPinnedActivitiesRequest {
   /**
    * Sorting parameters for the query
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filters to apply to the query
@@ -20730,7 +20874,7 @@ export interface QueryPinnedActivitiesResponse {
   /**
    * List of pinned activities matching the query
    */
-  pinned_activities: ActivityPinResponse[];
+  pinned_activities: Array<ActivityPinResponse>;
 
   /**
    * Cursor for next page
@@ -20753,7 +20897,7 @@ export interface QueryPollVotesRequest {
   /**
    * Array of sort parameters
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter to apply to the query
@@ -20771,7 +20915,7 @@ export interface QueryPollsRequest {
   /**
    * Array of sort parameters
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter to apply to the query
@@ -20788,7 +20932,23 @@ export interface QueryPollsResponse {
   /**
    * Polls data returned by the query
    */
-  polls: PollResponseData[];
+  polls: Array<PollResponseData>;
+
+  next?: string;
+
+  prev?: string;
+}
+
+export interface QueryPredefinedFiltersResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
+
+  /**
+   * Predefined filters
+   */
+  predefined_filters: Array<PredefinedFilterResponse>;
 
   next?: string;
 
@@ -20807,7 +20967,7 @@ export interface QueryReactionsRequest {
   /**
    * Array of sort parameters
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter to apply to the query
@@ -20826,7 +20986,7 @@ export interface QueryReactionsResponse {
    */
   duration: string;
 
-  reactions: ReactionResponse[];
+  reactions: Array<ReactionResponse>;
 
   next?: string;
 
@@ -20845,7 +21005,7 @@ export interface QueryRemindersRequest {
   /**
    * Array of sort parameters
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter to apply to the query
@@ -20867,7 +21027,7 @@ export interface QueryRemindersResponse {
   /**
    * MessageReminders data returned by the query
    */
-  reminders: ReminderResponseData[];
+  reminders: Array<ReminderResponseData>;
 
   next?: string;
 
@@ -20908,7 +21068,7 @@ export interface QueryReviewQueueRequest {
   /**
    * Sorting parameters for the results
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter conditions for review queue items. Accepts built-in fields (e.g. status, channel_cid, severity, recommended_action) and customer-supplied moderation_payload.custom keys: any key that is not a built-in field is matched against the item's custom moderation data (e.g. {"location_id": "loc-42"}). Use filter_config.filterable_custom_keys to discover which custom keys the app exposes as chips.
@@ -20927,12 +21087,12 @@ export interface QueryReviewQueueResponse {
   /**
    * List of review queue items
    */
-  items: ReviewQueueItemResponse[];
+  items: Array<ReviewQueueItemResponse>;
 
   /**
    * Configuration for moderation actions
    */
-  action_config: Record<string, ModerationActionConfigResponse[]>;
+  action_config: Record<string, Array<ModerationActionConfigResponse>>;
 
   /**
    * Statistics about the review queue
@@ -20943,7 +21103,7 @@ export interface QueryReviewQueueResponse {
 
   prev?: string;
 
-  default_action_config?: Record<string, ModerationActionConfigResponse[]>;
+  default_action_config?: Record<string, Array<ModerationActionConfigResponse>>;
 
   filter_config?: FilterConfigResponse;
 }
@@ -20963,7 +21123,7 @@ export interface QueryRevisionHistoryRequest {
   /**
    * Array of sort parameters
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 }
 
 export interface QueryRevisionHistoryResponse {
@@ -20975,7 +21135,7 @@ export interface QueryRevisionHistoryResponse {
   /**
    * Revision history entries
    */
-  revisions: RevisionHistoryResponse[];
+  revisions: Array<RevisionHistoryResponse>;
 
   next?: string;
 
@@ -20998,7 +21158,7 @@ export interface QuerySegmentTargetsRequest {
    */
   prev?: string;
 
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   filter?: Record<string, any>;
 }
@@ -21012,7 +21172,7 @@ export interface QuerySegmentTargetsResponse {
   /**
    * Targets
    */
-  targets: SegmentTargetResponse[];
+  targets: Array<SegmentTargetResponse>;
 
   next?: string;
 
@@ -21034,7 +21194,7 @@ export interface QuerySegmentsRequest {
   /**
    * Array of sort parameters
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 }
 
 export interface QuerySegmentsResponse {
@@ -21046,7 +21206,7 @@ export interface QuerySegmentsResponse {
   /**
    * Segments
    */
-  segments: SegmentResponse[];
+  segments: Array<SegmentResponse>;
 
   next?: string;
 
@@ -21078,6 +21238,11 @@ export interface QueryTeamUsageStatsRequest {
    * Start date in YYYY-MM-DD format. Used with end_date for custom date range. Returns daily breakdown.
    */
   start_date?: string;
+
+  /**
+   * Filter results to a single team ID. Empty string selects users not assigned to any team. Mutually exclusive with 'next'.
+   */
+  team?: string;
 }
 
 export interface QueryTeamUsageStatsResponse {
@@ -21089,7 +21254,7 @@ export interface QueryTeamUsageStatsResponse {
   /**
    * Array of team usage statistics
    */
-  teams: TeamUsageStats[];
+  teams: Array<TeamUsageStats>;
 
   /**
    * Cursor for pagination to fetch next page
@@ -21121,7 +21286,7 @@ export interface QueryThreadsRequest {
   /**
    * Array of sort parameters
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter to apply to the query
@@ -21143,7 +21308,7 @@ export interface QueryThreadsResponse {
   /**
    * List of enriched thread states
    */
-  threads: ThreadStateResponse[];
+  threads: Array<ThreadStateResponse>;
 
   next?: string;
 
@@ -21160,7 +21325,7 @@ export interface QueryUserFeedbackRequest {
   /**
    * Array of sort parameters
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Filter conditions to apply to the query
@@ -21174,7 +21339,7 @@ export interface QueryUserFeedbackResponse {
    */
   duration: string;
 
-  user_feedback: UserFeedbackResponse[];
+  user_feedback: Array<UserFeedbackResponse>;
 
   next?: string;
 
@@ -21200,7 +21365,7 @@ export interface QueryUsersPayload {
   /**
    * Array of sort parameters
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * User request object
@@ -21217,7 +21382,7 @@ export interface QueryUsersResponse {
   /**
    * Array of users as result of filters applied.
    */
-  users: FullUserResponse[];
+  users: Array<FullUserResponse>;
 }
 
 export interface QueueResponse {
@@ -21390,17 +21555,17 @@ export interface Reaction {
 
   score?: number;
 
-  target_feeds?: string[];
+  target_feeds?: Array<string>;
 
   children_counts?: Record<string, any>;
 
   data?: Record<string, any>;
 
-  latest_children?: Record<string, Reaction[]>;
+  latest_children?: Record<string, Array<Reaction>>;
 
   moderation?: Record<string, any>;
 
-  own_children?: Record<string, Reaction[]>;
+  own_children?: Record<string, Array<Reaction>>;
 
   target_feeds_extra_data?: Record<string, any>;
 
@@ -21462,7 +21627,7 @@ export interface ReactionDeletedEvent {
   /**
    * The participants of the thread
    */
-  thread_participants?: UserResponseCommonFields[];
+  thread_participants?: Array<UserResponseCommonFields>;
 
   channel_custom?: Record<string, any>;
 
@@ -21500,7 +21665,7 @@ export interface ReactionGroupResponse {
   /**
    * The most recent users who reacted with this type, ordered by most recent first.
    */
-  latest_reactions_by: ReactionGroupUserResponse[];
+  latest_reactions_by: Array<ReactionGroupUserResponse>;
 }
 
 export interface ReactionGroupUserResponse {
@@ -21575,7 +21740,7 @@ export interface ReactionNewEvent {
   /**
    * The participants of the thread
    */
-  thread_participants?: UserResponseCommonFields[];
+  thread_participants?: Array<UserResponseCommonFields>;
 
   channel_custom?: Record<string, any>;
 
@@ -21759,7 +21924,7 @@ export interface ReactivateUsersRequest {
   /**
    * User IDs to reactivate
    */
-  user_ids: string[];
+  user_ids: Array<string>;
 
   /**
    * ID of the user who's reactivating the users
@@ -21789,7 +21954,7 @@ export interface ReadCollectionsResponse {
   /**
    * List of collections matching the references
    */
-  collections: CollectionResponse[];
+  collections: Array<CollectionResponse>;
 }
 
 export interface ReadReceiptsResponse {
@@ -22086,7 +22251,7 @@ export interface RemoveUserGroupMembersRequest {
   /**
    * List of user IDs to remove
    */
-  member_ids: string[];
+  member_ids: Array<string>;
 
   team_id?: string;
 }
@@ -22135,7 +22300,7 @@ export interface ReportClientEventRequest {
   /**
    * Client-side events to report (1-100 per request)
    */
-  events: ClientEvent[];
+  events: Array<ClientEvent>;
 }
 
 export interface ReportClientEventResponse {
@@ -22311,7 +22476,7 @@ export interface RestoreFeedGroupResponse {
 }
 
 export interface RestoreUsersRequest {
-  user_ids: string[];
+  user_ids: Array<string>;
 }
 
 export interface RetentionPolicy {
@@ -22346,7 +22511,7 @@ export interface ReviewQueueItemNewEvent {
   /**
    * The flags associated with this review queue item
    */
-  flags?: ModerationFlagResponse[];
+  flags?: Array<ModerationFlagResponse>;
 
   action?: ActionLogResponse;
 
@@ -22416,22 +22581,22 @@ export interface ReviewQueueItemResponse {
   /**
    * Moderation actions taken
    */
-  actions: ActionLogResponse[];
+  actions: Array<ActionLogResponse>;
 
   /**
    * Associated ban records
    */
-  bans: BanInfoResponse[];
+  bans: Array<BanInfoResponse>;
 
   /**
    * Associated flag records
    */
-  flags: ModerationFlagResponse[];
+  flags: Array<ModerationFlagResponse>;
 
   /**
    * Detected languages in the content
    */
-  languages: string[];
+  languages: Array<string>;
 
   /**
    * When the review was completed
@@ -22463,7 +22628,7 @@ export interface ReviewQueueItemResponse {
   /**
    * Teams associated with this item
    */
-  teams?: string[];
+  teams?: Array<string>;
 
   activity?: EnrichedActivity;
 
@@ -22510,7 +22675,7 @@ export interface ReviewQueueItemUpdatedEvent {
   /**
    * The flags associated with this review queue item
    */
-  flags?: ModerationFlagResponse[];
+  flags?: Array<ModerationFlagResponse>;
 
   action?: ActionLogResponse;
 
@@ -22530,7 +22695,7 @@ export interface RevisionHistoryResponse {
 
   user_id: string;
 
-  changed_fields?: string[];
+  changed_fields?: Array<string>;
 
   previous_obj_serialized?: Record<string, any>;
 }
@@ -22544,7 +22709,7 @@ export interface RingCallRequest {
   /**
    * Members that should receive the ring. If no ids are provided, all call members who are not already in the call will receive ring notifications.
    */
-  members_ids?: string[];
+  members_ids?: Array<string>;
 }
 
 export interface RingCallResponse {
@@ -22553,7 +22718,7 @@ export interface RingCallResponse {
   /**
    * List of members ringing notification was sent to
    */
-  members_ids: string[];
+  members_ids: Array<string>;
 }
 
 export interface RingSettings {
@@ -22613,7 +22778,7 @@ export interface Role {
   /**
    * List of scopes where this role is currently present. `.app` means that role is present in app-level grants
    */
-  scopes: string[];
+  scopes: Array<string>;
 }
 
 export interface RuleBuilderAction {
@@ -22712,13 +22877,13 @@ export interface RuleBuilderCondition {
 export interface RuleBuilderConditionGroup {
   logic?: string;
 
-  conditions?: RuleBuilderCondition[];
+  conditions?: Array<RuleBuilderCondition>;
 }
 
 export interface RuleBuilderConfig {
   async?: boolean;
 
-  rules?: RuleBuilderRule[];
+  rules?: Array<RuleBuilderRule>;
 }
 
 export interface RuleBuilderRule {
@@ -22730,11 +22895,11 @@ export interface RuleBuilderRule {
 
   logic?: string;
 
-  action_sequences?: CallRuleActionSequence[];
+  action_sequences?: Array<CallRuleActionSequence>;
 
-  conditions?: RuleBuilderCondition[];
+  conditions?: Array<RuleBuilderCondition>;
 
-  groups?: RuleBuilderConditionGroup[];
+  groups?: Array<RuleBuilderConditionGroup>;
 
   action?: RuleBuilderAction;
 }
@@ -22772,7 +22937,7 @@ export interface SDKUsageReport {
 }
 
 export interface SDKUsageReportResponse {
-  daily: DailyAggregateSDKUsageReportResponse[];
+  daily: Array<DailyAggregateSDKUsageReportResponse>;
 }
 
 export interface SFULocationResponse {
@@ -22905,12 +23070,12 @@ export interface SIPChallengeRequest {
   /**
    * Domain list
    */
-  domain?: string[];
+  domain?: Array<string>;
 
   /**
    * Quality of protection options
    */
-  qop?: string[];
+  qop?: Array<string>;
 }
 
 export interface SIPDirectRoutingRuleCallConfigsRequest {
@@ -23000,7 +23165,7 @@ export interface SIPInboundRoutingRuleRequest {
   /**
    * List of SIP trunk IDs
    */
-  trunk_ids: string[];
+  trunk_ids: Array<string>;
 
   /**
    * Configuration for SIP caller settings
@@ -23010,12 +23175,12 @@ export interface SIPInboundRoutingRuleRequest {
   /**
    * List of called numbers
    */
-  called_numbers?: string[];
+  called_numbers?: Array<string>;
 
   /**
    * List of caller numbers (optional)
    */
-  caller_numbers?: string[];
+  caller_numbers?: Array<string>;
 
   /**
    * Configuration for SIP call settings
@@ -23064,17 +23229,17 @@ export interface SIPInboundRoutingRuleResponse {
   /**
    * List of called numbers
    */
-  called_numbers: string[];
+  called_numbers: Array<string>;
 
   /**
    * List of SIP trunk IDs
    */
-  trunk_ids: string[];
+  trunk_ids: Array<string>;
 
   /**
    * List of caller numbers
    */
-  caller_numbers?: string[];
+  caller_numbers?: Array<string>;
 
   /**
    * SIP call configuration response
@@ -23185,12 +23350,12 @@ export interface SIPTrunkResponse {
   /**
    * Allowed IPv4/IPv6 addresses or CIDR blocks
    */
-  allowed_ips: string[];
+  allowed_ips: Array<string>;
 
   /**
    * Phone numbers associated with this SIP trunk
    */
-  numbers: string[];
+  numbers: Array<string>;
 }
 
 export interface SRTIngress {
@@ -23262,7 +23427,7 @@ export interface SearchPayload {
   /**
    * Sort parameters. Cannot be used with non-zero offset
    */
-  sort?: SortParamRequest[];
+  sort?: Array<SortParamRequest>;
 
   /**
    * Message filter conditions
@@ -23281,7 +23446,7 @@ export interface SearchResponse {
   /**
    * Search results
    */
-  results: SearchResult[];
+  results: Array<SearchResult>;
 
   /**
    * Value to pass to the next search query in order to paginate
@@ -23329,15 +23494,15 @@ export interface SearchResultMessage {
 
   updated_at: Date;
 
-  attachments: Attachment[];
+  attachments: Array<Attachment>;
 
-  latest_reactions: ReactionResponse[];
+  latest_reactions: Array<ReactionResponse>;
 
-  mentioned_users: UserResponse[];
+  mentioned_users: Array<UserResponse>;
 
-  own_reactions: ReactionResponse[];
+  own_reactions: Array<ReactionResponse>;
 
-  restricted_visibility: string[];
+  restricted_visibility: Array<string>;
 
   custom: Record<string, any>;
 
@@ -23372,13 +23537,13 @@ export interface SearchResultMessage {
 
   show_in_channel?: boolean;
 
-  mentioned_group_ids?: string[];
+  mentioned_group_ids?: Array<string>;
 
-  mentioned_groups?: UserGroupResponse[];
+  mentioned_groups?: Array<UserGroupResponse>;
 
-  mentioned_roles?: string[];
+  mentioned_roles?: Array<string>;
 
-  thread_participants?: UserResponse[];
+  thread_participants?: Array<UserResponse>;
 
   /**
    * Represents channel in chat
@@ -23389,7 +23554,7 @@ export interface SearchResultMessage {
 
   i18n?: Record<string, string>;
 
-  image_labels?: Record<string, string[]>;
+  image_labels?: Record<string, Array<string>>;
 
   member?: ChannelMemberPartialResponse;
 
@@ -23420,7 +23585,7 @@ export interface SearchRolesResponse {
   /**
    * Matching roles, sorted ascending by name
    */
-  roles: Role[];
+  roles: Array<Role>;
 }
 
 export interface SearchUserGroupsResponse {
@@ -23429,7 +23594,7 @@ export interface SearchUserGroupsResponse {
   /**
    * List of matching user groups
    */
-  user_groups: UserGroupResponse[];
+  user_groups: Array<UserGroupResponse>;
 }
 
 export interface SearchWarning {
@@ -23451,7 +23616,7 @@ export interface SearchWarning {
   /**
    * Channel CIDs for the searched channels
    */
-  channel_search_cids?: string[];
+  channel_search_cids?: Array<string>;
 }
 
 export interface Segment {
@@ -23517,15 +23682,15 @@ export interface SegmentTargetResponse {
 export interface Segments {
   by_country_reason: string;
 
-  by_browser: BroadcastSegment[];
+  by_browser: Array<BroadcastSegment>;
 
-  by_country: BroadcastSegment[];
+  by_country: Array<BroadcastSegment>;
 
-  by_delivery_zone: DeliveryZoneSegment[];
+  by_delivery_zone: Array<DeliveryZoneSegment>;
 
-  by_os: BroadcastSegment[];
+  by_os: Array<BroadcastSegment>;
 
-  by_sdk: BroadcastSegment[];
+  by_sdk: Array<BroadcastSegment>;
 }
 
 export interface SendCallEventRequest {
@@ -23855,7 +24020,7 @@ export interface SharedLocationResponseData {
 export interface SharedLocationsResponse {
   duration: string;
 
-  active_live_locations: SharedLocationResponseData[];
+  active_live_locations: Array<SharedLocationResponseData>;
 }
 
 export interface ShowChannelRequest {
@@ -23922,6 +24087,14 @@ export interface SipInboundCredentials {
   user_custom_data: Record<string, any>;
 }
 
+export interface SortParam {
+  direction: number;
+
+  field: string;
+
+  type: string;
+}
+
 export interface SortParamRequest {
   /**
    * Direction of sorting, 1 for Ascending, -1 for Descending, default is 1. One of: -1, 1
@@ -23944,9 +24117,9 @@ export interface SourceHealth {
 
   dead_air_s: number;
 
-  interruptions: SourceInterruption[];
+  interruptions: Array<SourceInterruption>;
 
-  publisher_sessions: PublisherSession[];
+  publisher_sessions: Array<PublisherSession>;
 }
 
 export interface SourceInterruption {
@@ -24071,7 +24244,7 @@ export interface StartRTMPBroadcastsRequest {
   /**
    * List of broadcasts to start
    */
-  broadcasts: RTMPBroadcastRequest[];
+  broadcasts: Array<RTMPBroadcastRequest>;
 }
 
 export interface StartRTMPBroadcastsResponse {
@@ -24287,12 +24460,12 @@ export interface StoriesFeedUpdatedEvent {
   /**
    * Individual activities for stories feeds
    */
-  activities?: ActivityResponse[];
+  activities?: Array<ActivityResponse>;
 
   /**
    * Aggregated activities for stories feeds
    */
-  aggregated_activities?: AggregatedActivityResponse[];
+  aggregated_activities?: Array<AggregatedActivityResponse>;
 
   user?: UserResponseCommonFields;
 }
@@ -24403,7 +24576,7 @@ export interface SubmitActionRequest {
   reject_appeal?: RejectAppealRequestPayload;
 
   /**
-   * Configuration for restore action
+   * Configuration for restore action. State-aware: reverses whichever of a delete, a block, or a shadow block currently applies to the content (including both a delete and a block/shadow block at once).
    */
   restore?: RestoreActionRequestPayload;
 
@@ -24418,7 +24591,7 @@ export interface SubmitActionRequest {
   unban?: UnbanActionRequestPayload;
 
   /**
-   * Configuration for unblock action
+   * Deprecated: use restore instead — it now also reverses a block or shadow block. Configuration for unblock action.
    */
   unblock?: UnblockActionRequestPayload;
 
@@ -24480,12 +24653,12 @@ export interface SubmitModerationFeedbackRequest {
   /**
    * Classifications originally produced by the moderation system
    */
-  current_labels?: string[];
+  current_labels?: Array<string>;
 
   /**
    * Optional moderator-supplied classifications (up to 16 entries)
    */
-  expected_labels?: string[];
+  expected_labels?: Array<string>;
 }
 
 export interface SubmitModerationFeedbackResponse {
@@ -24529,11 +24702,11 @@ export interface SubscribersMetrics {
 }
 
 export interface Supporting {
-  delivery_incident_windows: Incident[];
+  delivery_incident_windows: Array<Incident>;
 
-  edge_outlier_zones: string[];
+  edge_outlier_zones: Array<string>;
 
-  source_drop_windows: TimeWindow[];
+  source_drop_windows: Array<TimeWindow>;
 }
 
 export interface TargetResolution {
@@ -24642,9 +24815,9 @@ export interface TextContentParameters {
 
   text_length_operator?: string;
 
-  blocklist_match?: string[];
+  blocklist_match?: Array<string>;
 
-  harm_labels?: string[];
+  harm_labels?: Array<string>;
 
   llm_harm_labels?: Record<string, string>;
 }
@@ -24660,11 +24833,11 @@ export interface TextRuleParameters {
 
   time_window?: string;
 
-  blocklist_match?: string[];
+  blocklist_match?: Array<string>;
 
-  harm_labels?: string[];
+  harm_labels?: Array<string>;
 
-  semantic_filter_names?: string[];
+  semantic_filter_names?: Array<string>;
 
   llm_harm_labels?: Record<string, string>;
 }
@@ -24768,7 +24941,7 @@ export interface ThreadResponse {
   /**
    * Thread Participants
    */
-  thread_participants?: ThreadParticipant[];
+  thread_participants?: Array<ThreadParticipant>;
 
   /**
    * Represents channel in chat
@@ -24832,7 +25005,7 @@ export interface ThreadStateResponse {
    */
   updated_at: Date;
 
-  latest_replies: MessageResponse[];
+  latest_replies: Array<MessageResponse>;
 
   /**
    * Custom data for this object
@@ -24849,12 +25022,12 @@ export interface ThreadStateResponse {
    */
   last_message_at?: Date;
 
-  read?: ReadStateResponse[];
+  read?: Array<ReadStateResponse>;
 
   /**
    * Thread Participants
    */
-  thread_participants?: ThreadParticipant[];
+  thread_participants?: Array<ThreadParticipant>;
 
   /**
    * Represents channel in chat
@@ -24923,9 +25096,9 @@ export interface ThreadedCommentResponse {
 
   upvote_count: number;
 
-  mentioned_users: UserResponse[];
+  mentioned_users: Array<UserResponse>;
 
-  own_reactions: FeedsReactionResponse[];
+  own_reactions: Array<FeedsReactionResponse>;
 
   /**
    * User response object
@@ -24942,14 +25115,14 @@ export interface ThreadedCommentResponse {
 
   text?: string;
 
-  attachments?: Attachment[];
+  attachments?: Array<Attachment>;
 
-  latest_reactions?: FeedsReactionResponse[];
+  latest_reactions?: Array<FeedsReactionResponse>;
 
   /**
    * Slice of nested comments (may be empty).
    */
-  replies?: ThreadedCommentResponse[];
+  replies?: Array<ThreadedCommentResponse>;
 
   custom?: Record<string, any>;
 
@@ -25050,7 +25223,7 @@ export interface TrackActivityMetricsRequest {
   /**
    * List of metric events to track (max 100 per request)
    */
-  events: TrackActivityMetricsEvent[];
+  events: Array<TrackActivityMetricsEvent>;
 
   user_id?: string;
 
@@ -25066,7 +25239,7 @@ export interface TrackActivityMetricsResponse {
   /**
    * Results for each event in the request, in the same order
    */
-  results: TrackActivityMetricsEventResult[];
+  results: Array<TrackActivityMetricsEventResult>;
 }
 
 export interface TrackStatsResponse {
@@ -25330,7 +25503,7 @@ export interface TranslateMessageRequest {
 export interface TranslationSettings {
   enabled?: boolean;
 
-  languages?: string[];
+  languages?: Array<string>;
 }
 
 export interface TriggeredRuleResponse {
@@ -25342,7 +25515,7 @@ export interface TriggeredRuleResponse {
   /**
    * Action types resolved from the rule's action sequence
    */
-  actions: string[];
+  actions: Array<string>;
 
   /**
    * Name of the moderation rule that triggered
@@ -25383,7 +25556,7 @@ export interface TruncateChannelRequest {
   /**
    * List of member IDs to hide message history for. If empty, truncates the channel for all members
    */
-  member_ids?: string[];
+  member_ids?: Array<string>;
 
   /**
    * Message data for creating or updating a message
@@ -25533,7 +25706,7 @@ export interface UnfollowBatchRequest {
   /**
    * List of follow relationships to remove, each with optional keep_history
    */
-  follows: UnfollowPair[];
+  follows: Array<UnfollowPair>;
 
   /**
    * Whether to delete the corresponding notification activity (default: false)
@@ -25552,7 +25725,7 @@ export interface UnfollowBatchResponse {
   /**
    * List of follow relationships that were removed
    */
-  follows: FollowResponse[];
+  follows: Array<FollowResponse>;
 }
 
 export interface UnfollowPair {
@@ -25589,7 +25762,7 @@ export interface UnmuteChannelRequest {
   /**
    * Channel CIDs to mute (if multiple channels)
    */
-  channel_cids?: string[];
+  channel_cids?: Array<string>;
 
   /**
    * User request object
@@ -25601,7 +25774,7 @@ export interface UnmuteRequest {
   /**
    * User IDs to unmute
    */
-  target_ids: string[];
+  target_ids: Array<string>;
 
   user_id?: string;
 
@@ -25617,7 +25790,7 @@ export interface UnmuteResponse {
   /**
    * A list of users that can't be found. Common cause for this is deleted users
    */
-  non_existing_users?: string[];
+  non_existing_users?: Array<string>;
 }
 
 export interface UnpinActivityResponse {
@@ -25656,7 +25829,7 @@ export interface UnpinResponse {
 }
 
 export interface UnreadCountsBatchRequest {
-  user_ids: string[];
+  user_ids: Array<string>;
 }
 
 export interface UnreadCountsBatchResponse {
@@ -25689,11 +25862,11 @@ export interface UnreadCountsResponse {
 
   total_unread_threads_count: number;
 
-  channel_type: UnreadCountsChannelType[];
+  channel_type: Array<UnreadCountsChannelType>;
 
-  channels: UnreadCountsChannel[];
+  channels: Array<UnreadCountsChannel>;
 
-  threads: UnreadCountsThread[];
+  threads: Array<UnreadCountsThread>;
 
   total_unread_count_by_team?: Record<string, number>;
 }
@@ -25712,7 +25885,7 @@ export interface UpdateActivitiesPartialBatchRequest {
   /**
    * List of activity changes to apply. Each change specifies an activity ID and the fields to set/unset
    */
-  changes: UpdateActivityPartialChangeRequest[];
+  changes: Array<UpdateActivityPartialChangeRequest>;
 
   /**
    * If true, forces moderation to run for server-side requests. By default, server-side requests skip moderation. Client-side requests always run moderation regardless of this field.
@@ -25726,7 +25899,7 @@ export interface UpdateActivitiesPartialBatchResponse {
   /**
    * List of successfully updated activities
    */
-  activities: ActivityResponse[];
+  activities: Array<ActivityResponse>;
 }
 
 export interface UpdateActivityPartialChangeRequest {
@@ -25749,7 +25922,7 @@ export interface UpdateActivityPartialChangeRequest {
   /**
    * List of field names to remove. Supported fields: 'custom', 'location', 'expires_at', 'filter_tags', 'interest_tags', 'attachments', 'poll_id', 'mentioned_user_ids'. Use dot-notation for nested custom fields (e.g., 'custom.field_name')
    */
-  unset?: string[];
+  unset?: Array<string>;
 
   /**
    * Map of field names to new values. Supported fields: 'text', 'attachments', 'custom', 'visibility', 'visibility_tag', 'restrict_replies' (values: 'everyone', 'people_i_follow', 'nobody'), 'location', 'expires_at', 'filter_tags', 'interest_tags', 'poll_id', 'feeds', 'mentioned_user_ids'. For custom fields, use dot-notation (e.g., 'custom.field_name')
@@ -25789,7 +25962,7 @@ export interface UpdateActivityPartialRequest {
   /**
    * List of field names to remove. Supported fields: 'custom', 'visibility_tag', 'location', 'expires_at', 'filter_tags', 'interest_tags', 'attachments', 'poll_id', 'mentioned_user_ids', 'search_data'. Use dot-notation for nested custom fields (e.g., 'custom.field_name')
    */
-  unset?: string[];
+  unset?: Array<string>;
 
   /**
    * Map of field names to new values. Supported fields: 'text', 'attachments', 'custom', 'visibility', 'visibility_tag', 'restrict_replies' (values: 'everyone', 'people_i_follow', 'nobody'), 'location', 'expires_at', 'filter_tags', 'interest_tags', 'poll_id', 'feeds', 'mentioned_user_ids', 'search_data'. For custom fields, use dot-notation (e.g., 'custom.field_name')
@@ -25877,32 +26050,32 @@ export interface UpdateActivityRequest {
   /**
    * List of attachments for the activity
    */
-  attachments?: Attachment[];
+  attachments?: Array<Attachment>;
 
   /**
    * Collections that this activity references
    */
-  collection_refs?: string[];
+  collection_refs?: Array<string>;
 
   /**
    * List of feeds the activity is present in
    */
-  feeds?: string[];
+  feeds?: Array<string>;
 
   /**
    * Tags used for filtering the activity
    */
-  filter_tags?: string[];
+  filter_tags?: Array<string>;
 
   /**
    * Tags indicating interest categories
    */
-  interest_tags?: string[];
+  interest_tags?: Array<string>;
 
   /**
    * List of user IDs mentioned in the activity
    */
-  mentioned_user_ids?: string[];
+  mentioned_user_ids?: Array<string>;
 
   /**
    * Custom data for the activity
@@ -26029,17 +26202,17 @@ export interface UpdateAppRequest {
 
   webhook_url?: string;
 
-  allowed_flag_reasons?: string[];
+  allowed_flag_reasons?: Array<string>;
 
-  event_hooks?: EventHook[];
+  event_hooks?: Array<EventHook>;
 
-  image_moderation_block_labels?: string[];
+  image_moderation_block_labels?: Array<string>;
 
-  image_moderation_labels?: string[];
+  image_moderation_labels?: Array<string>;
 
-  user_search_disallowed_roles?: string[];
+  user_search_disallowed_roles?: Array<string>;
 
-  webhook_events?: string[];
+  webhook_events?: Array<string>;
 
   activity_metrics_config?: Record<string, number>;
 
@@ -26053,7 +26226,7 @@ export interface UpdateAppRequest {
 
   firebase_config?: FirebaseConfig;
 
-  grants?: Record<string, string[]>;
+  grants?: Record<string, Array<string>>;
 
   huawei_config?: HuaweiConfig;
 
@@ -26082,7 +26255,7 @@ export interface UpdateBlockListRequest {
   /**
    * List of words to block
    */
-  words?: string[];
+  words?: Array<string>;
 
   /**
    * User request object
@@ -26163,12 +26336,12 @@ export interface UpdateCallMembersRequest {
   /**
    * List of userID to remove
    */
-  remove_members?: string[];
+  remove_members?: Array<string>;
 
   /**
    * List of members to update or insert
    */
-  update_members?: MemberRequest[];
+  update_members?: Array<MemberRequest>;
 }
 
 export interface UpdateCallMembersResponse {
@@ -26177,7 +26350,7 @@ export interface UpdateCallMembersResponse {
    */
   duration: string;
 
-  members: MemberResponse[];
+  members: Array<MemberResponse>;
 }
 
 export interface UpdateCallRequest {
@@ -26197,9 +26370,9 @@ export interface UpdateCallRequest {
 export interface UpdateCallResponse {
   duration: string;
 
-  members: MemberResponse[];
+  members: Array<MemberResponse>;
 
-  own_capabilities: OwnCapability[];
+  own_capabilities: Array<OwnCapability>;
 
   /**
    * Represents a call
@@ -26210,7 +26383,7 @@ export interface UpdateCallResponse {
 export interface UpdateCallTypeRequest {
   external_storage?: string;
 
-  grants?: Record<string, string[]>;
+  grants?: Record<string, Array<string>>;
 
   notification_settings?: NotificationSettingsRequest;
 
@@ -26238,7 +26411,7 @@ export interface UpdateCallTypeResponse {
   /**
    * the permissions granted to each role
    */
-  grants: Record<string, string[]>;
+  grants: Record<string, Array<string>>;
 
   notification_settings: NotificationSettingsResponse;
 
@@ -26273,9 +26446,9 @@ export interface UpdateCampaignRequest {
 
   skip_webhook?: boolean;
 
-  segment_ids?: string[];
+  segment_ids?: Array<string>;
 
-  user_ids?: string[];
+  user_ids?: Array<string>;
 
   channel_template?: CampaignChannelTemplate;
 }
@@ -26283,7 +26456,7 @@ export interface UpdateCampaignRequest {
 export interface UpdateChannelPartialRequest {
   user_id?: string;
 
-  unset?: string[];
+  unset?: Array<string>;
 
   set?: Record<string, any>;
 
@@ -26302,7 +26475,7 @@ export interface UpdateChannelPartialResponse {
   /**
    * List of updated members
    */
-  members: ChannelMemberResponse[];
+  members: Array<ChannelMemberResponse>;
 
   /**
    * Represents channel in chat
@@ -26346,42 +26519,42 @@ export interface UpdateChannelRequest {
   /**
    * List of filter tags to add to the channel
    */
-  add_filter_tags?: string[];
+  add_filter_tags?: Array<string>;
 
   /**
    * List of user IDs to add to the channel
    */
-  add_members?: ChannelMemberRequest[];
+  add_members?: Array<ChannelMemberRequest>;
 
   /**
    * List of user IDs to make channel moderators
    */
-  add_moderators?: string[];
+  add_moderators?: Array<string>;
 
   /**
    * List of channel member role assignments. If any specified user is not part of the channel, the request will fail
    */
-  assign_roles?: ChannelMemberRequest[];
+  assign_roles?: Array<ChannelMemberRequest>;
 
   /**
    * List of user IDs to take away moderators status from
    */
-  demote_moderators?: string[];
+  demote_moderators?: Array<string>;
 
   /**
    * List of user IDs to invite to the channel
    */
-  invites?: ChannelMemberRequest[];
+  invites?: Array<ChannelMemberRequest>;
 
   /**
    * List of filter tags to remove from the channel
    */
-  remove_filter_tags?: string[];
+  remove_filter_tags?: Array<string>;
 
   /**
    * List of user IDs to remove from the channel
    */
-  remove_members?: string[];
+  remove_members?: Array<string>;
 
   data?: ChannelInputRequest;
 
@@ -26405,7 +26578,7 @@ export interface UpdateChannelResponse {
   /**
    * List of channel members
    */
-  members: ChannelMemberResponse[];
+  members: Array<ChannelMemberResponse>;
 
   /**
    * Represents channel in chat
@@ -26475,16 +26648,16 @@ export interface UpdateChannelTypeRequest {
 
   user_message_reminders?: boolean;
 
-  allowed_flag_reasons?: string[];
+  allowed_flag_reasons?: Array<string>;
 
-  blocklists?: BlockListOptions[];
+  blocklists?: Array<BlockListOptions>;
 
   /**
    * List of commands that channel supports
    */
-  commands?: string[];
+  commands?: Array<string>;
 
-  permissions?: PolicyRequest[];
+  permissions?: Array<PolicyRequest>;
 
   /**
    * Sets thresholds for AI moderation
@@ -26493,7 +26666,7 @@ export interface UpdateChannelTypeRequest {
 
   chat_preferences?: ChatPreferences;
 
-  grants?: Record<string, string[]>;
+  grants?: Record<string, Array<string>>;
 }
 
 export interface UpdateChannelTypeResponse {
@@ -26551,11 +26724,11 @@ export interface UpdateChannelTypeResponse {
 
   user_message_reminders: boolean;
 
-  commands: string[];
+  commands: Array<string>;
 
-  permissions: PolicyRequest[];
+  permissions: Array<PolicyRequest>;
 
-  grants: Record<string, string[]>;
+  grants: Record<string, Array<string>>;
 
   blocklist?: string;
 
@@ -26567,9 +26740,9 @@ export interface UpdateChannelTypeResponse {
 
   push_level?: 'all' | 'all_mentions' | 'mentions' | 'direct_mentions' | 'none';
 
-  allowed_flag_reasons?: string[];
+  allowed_flag_reasons?: Array<string>;
 
-  blocklists?: BlockListOptions[];
+  blocklists?: Array<BlockListOptions>;
 
   /**
    * Sets thresholds for AI moderation
@@ -26600,7 +26773,7 @@ export interface UpdateCollectionsRequest {
   /**
    * List of collections to update (only custom data is updatable)
    */
-  collections: UpdateCollectionRequest[];
+  collections: Array<UpdateCollectionRequest>;
 
   user_id?: string;
 
@@ -26616,7 +26789,7 @@ export interface UpdateCollectionsResponse {
   /**
    * List of updated collections
    */
-  collections: CollectionResponse[];
+  collections: Array<CollectionResponse>;
 }
 
 export interface UpdateCommandRequest {
@@ -26709,7 +26882,7 @@ export interface UpdateCommentPartialRequest {
   /**
    * List of field names to remove. Supported fields: 'custom', 'attachments', 'mentioned_user_ids', 'status'. Use dot-notation for nested custom fields (e.g., 'custom.field_name')
    */
-  unset?: string[];
+  unset?: Array<string>;
 
   /**
    * Map of field names to new values. Supported fields: 'text', 'attachments', 'custom', 'mentioned_user_ids', 'status'. Use dot-notation for nested custom fields (e.g., 'custom.field_name')
@@ -26762,12 +26935,12 @@ export interface UpdateCommentRequest {
   /**
    * Updated media attachments for the comment. Providing this field will replace all existing attachments.
    */
-  attachments?: Attachment[];
+  attachments?: Array<Attachment>;
 
   /**
    * List of user IDs mentioned in the comment
    */
-  mentioned_user_ids?: string[];
+  mentioned_user_ids?: Array<string>;
 
   /**
    * Updated custom data for the comment
@@ -26838,12 +27011,12 @@ export interface UpdateFeedGroupRequest {
   /**
    * Configuration for activity processors
    */
-  activity_processors?: ActivityProcessorConfig[];
+  activity_processors?: Array<ActivityProcessorConfig>;
 
   /**
    * Configuration for activity selectors
    */
-  activity_selectors?: ActivitySelectorConfig[];
+  activity_selectors?: Array<ActivitySelectorConfig>;
 
   activity_filter?: ActivityFilterConfig;
 
@@ -26885,7 +27058,7 @@ export interface UpdateFeedMembersRequest {
   /**
    * List of members to upsert, remove, or set
    */
-  members?: FeedMemberRequest[];
+  members?: Array<FeedMemberRequest>;
 }
 
 export interface UpdateFeedMembersResponse {
@@ -26894,11 +27067,11 @@ export interface UpdateFeedMembersResponse {
    */
   duration: string;
 
-  added: FeedMemberResponse[];
+  added: Array<FeedMemberResponse>;
 
-  removed_ids: string[];
+  removed_ids: Array<string>;
 
-  updated: FeedMemberResponse[];
+  updated: Array<FeedMemberResponse>;
 }
 
 export interface UpdateFeedRequest {
@@ -26930,7 +27103,7 @@ export interface UpdateFeedRequest {
   /**
    * Tags used for filtering feeds
    */
-  filter_tags?: string[];
+  filter_tags?: Array<string>;
 
   /**
    * Custom data for the feed
@@ -26950,7 +27123,7 @@ export interface UpdateFeedViewRequest {
   /**
    * Updated configuration for selecting activities
    */
-  activity_selectors?: ActivitySelectorConfig[];
+  activity_selectors?: Array<ActivitySelectorConfig>;
 
   aggregation?: AggregationConfig;
 
@@ -26967,7 +27140,7 @@ export interface UpdateFeedVisibilityRequest {
   /**
    * Updated permission grants for each role
    */
-  grants?: Record<string, string[]>;
+  grants?: Record<string, Array<string>>;
 }
 
 export interface UpdateFeedVisibilityResponse {
@@ -27067,7 +27240,7 @@ export interface UpdateLiveLocationRequest {
 }
 
 export interface UpdateMemberPartialRequest {
-  unset?: string[];
+  unset?: Array<string>;
 
   set?: Record<string, any>;
 }
@@ -27100,7 +27273,7 @@ export interface UpdateMembershipLevelRequest {
   /**
    * Activity tags this membership level gives access to
    */
-  tags?: string[];
+  tags?: Array<string>;
 
   /**
    * Custom data for the membership level
@@ -27127,7 +27300,7 @@ export interface UpdateMessagePartialRequest {
   /**
    * Array of field names to unset
    */
-  unset?: string[];
+  unset?: Array<string>;
 
   /**
    * Sets new field values
@@ -27215,7 +27388,7 @@ export interface UpdatePollPartialRequest {
   /**
    * Array of field names to unset
    */
-  unset?: string[];
+  unset?: Array<string>;
 
   /**
    * Sets new field values
@@ -27280,7 +27453,7 @@ export interface UpdatePollRequest {
   /**
    * Poll options
    */
-  options?: PollOptionRequest[];
+  options?: Array<PollOptionRequest>;
 
   /**
    * Custom data for this object
@@ -27291,6 +27464,35 @@ export interface UpdatePollRequest {
    * User request object
    */
   user?: UserRequest;
+}
+
+export interface UpdatePredefinedFilterRequest {
+  /**
+   * The operation this filter is for (e.g., QueryChannels)
+   */
+
+  operation: 'QueryChannels';
+
+  /**
+   * Filter to apply to the query
+   */
+  filter: Record<string, any>;
+
+  /**
+   * The description of the predefined filter
+   */
+  description?: string;
+
+  sort?: Array<Record<string, any>>;
+}
+
+export interface UpdatePredefinedFilterResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
+
+  predefined_filter?: PredefinedFilterResponse;
 }
 
 export interface UpdateQueueRequest {
@@ -27339,7 +27541,7 @@ export interface UpdateSIPInboundRoutingRuleRequest {
   /**
    * List of SIP trunk IDs
    */
-  trunk_ids: string[];
+  trunk_ids: Array<string>;
 
   /**
    * Configuration for SIP caller settings
@@ -27349,12 +27551,12 @@ export interface UpdateSIPInboundRoutingRuleRequest {
   /**
    * List of called numbers
    */
-  called_numbers?: string[];
+  called_numbers?: Array<string>;
 
   /**
    * List of caller numbers (optional)
    */
-  caller_numbers?: string[];
+  caller_numbers?: Array<string>;
 
   /**
    * Configuration for SIP call settings
@@ -27395,7 +27597,7 @@ export interface UpdateSIPTrunkRequest {
   /**
    * Phone numbers associated with this SIP trunk
    */
-  numbers: string[];
+  numbers: Array<string>;
 
   /**
    * Optional password for SIP trunk authentication
@@ -27405,7 +27607,7 @@ export interface UpdateSIPTrunkRequest {
   /**
    * Optional list of allowed IPv4/IPv6 addresses or CIDR blocks
    */
-  allowed_ips?: string[];
+  allowed_ips?: Array<string>;
 }
 
 export interface UpdateSIPTrunkResponse {
@@ -27449,7 +27651,7 @@ export interface UpdateThreadPartialRequest {
   /**
    * Array of field names to unset
    */
-  unset?: string[];
+  unset?: Array<string>;
 
   /**
    * Sets new field values
@@ -27497,7 +27699,7 @@ export interface UpdateUserPartialRequest {
    */
   id: string;
 
-  unset?: string[];
+  unset?: Array<string>;
 
   set?: Record<string, any>;
 }
@@ -27505,9 +27707,9 @@ export interface UpdateUserPartialRequest {
 export interface UpdateUserPermissionsRequest {
   user_id: string;
 
-  grant_permissions?: string[];
+  grant_permissions?: Array<string>;
 
-  revoke_permissions?: string[];
+  revoke_permissions?: Array<string>;
 }
 
 export interface UpdateUserPermissionsResponse {
@@ -27518,7 +27720,7 @@ export interface UpdateUserPermissionsResponse {
 }
 
 export interface UpdateUsersPartialRequest {
-  users: UpdateUserPartialRequest[];
+  users: Array<UpdateUserPartialRequest>;
 }
 
 export interface UpdateUsersRequest {
@@ -27550,7 +27752,7 @@ export interface UpdatedCallPermissionsEvent {
   /**
    * The capabilities of the current user
    */
-  own_capabilities: OwnCapability[];
+  own_capabilities: Array<OwnCapability>;
 
   /**
    * User response object
@@ -27597,7 +27799,7 @@ export interface UploadChannelRequest {
   /**
    * field with JSON-encoded array of image size configurations
    */
-  upload_sizes?: ImageSize[];
+  upload_sizes?: Array<ImageSize>;
 
   user?: OnlyUserID;
 }
@@ -27617,7 +27819,7 @@ export interface UploadChannelResponse {
   /**
    * Array of image size configurations
    */
-  upload_sizes?: ImageSize[];
+  upload_sizes?: Array<ImageSize>;
 }
 
 export interface UpsertActionConfigItem {
@@ -27703,7 +27905,7 @@ export interface UpsertActivitiesRequest {
   /**
    * List of activities to create or update
    */
-  activities: ActivityRequest[];
+  activities: Array<ActivityRequest>;
 
   /**
    * Server-side only. If true, auto-creates users referenced by activity user_id values that don't already exist. Default: false.
@@ -27727,7 +27929,7 @@ export interface UpsertActivitiesResponse {
   /**
    * List of created or updated activities
    */
-  activities: ActivityResponse[];
+  activities: Array<ActivityResponse>;
 
   /**
    * Total number of mention notification activities created for mentioned users across all activities
@@ -27739,7 +27941,7 @@ export interface UpsertCollectionsRequest {
   /**
    * List of collections to upsert (insert if new, update if existing)
    */
-  collections: CollectionRequest[];
+  collections: Array<CollectionRequest>;
 }
 
 export interface UpsertCollectionsResponse {
@@ -27748,7 +27950,7 @@ export interface UpsertCollectionsResponse {
   /**
    * List of upserted collections
    */
-  collections: CollectionResponse[];
+  collections: Array<CollectionResponse>;
 }
 
 export interface UpsertConfigRequest {
@@ -27893,22 +28095,22 @@ export interface UpsertModerationRuleRequest {
   /**
    * Escalation sequences for call rules
    */
-  action_sequences?: CallRuleActionSequence[];
+  action_sequences?: Array<CallRuleActionSequence>;
 
   /**
    * Flat list of conditions (legacy)
    */
-  conditions?: RuleBuilderCondition[];
+  conditions?: Array<RuleBuilderCondition>;
 
   /**
    * List of config keys this rule applies to
    */
-  config_keys?: string[];
+  config_keys?: Array<string>;
 
   /**
    * Nested condition groups
    */
-  groups?: RuleBuilderConditionGroup[];
+  groups?: Array<RuleBuilderConditionGroup>;
 
   action?: RuleBuilderAction;
 
@@ -27967,7 +28169,7 @@ export interface UpsertPushPreferencesRequest {
   /**
    * A list of push preferences for channels, calls, or the user.
    */
-  preferences: PushPreferenceInput[];
+  preferences: Array<PushPreferenceInput>;
 }
 
 export interface UpsertPushPreferencesResponse {
@@ -28241,7 +28443,7 @@ export interface UserFeedbackReport {
 }
 
 export interface UserFeedbackReportResponse {
-  daily: DailyAggregateUserFeedbackReportResponse[];
+  daily: Array<DailyAggregateUserFeedbackReportResponse>;
 }
 
 export interface UserFeedbackResponse {
@@ -28314,7 +28516,7 @@ export interface UserGroup {
 
   team_id?: string;
 
-  members?: UserGroupMember[];
+  members?: Array<UserGroupMember>;
 }
 
 export interface UserGroupCreatedEvent {
@@ -28378,7 +28580,7 @@ export interface UserGroupMemberAddedEvent {
   /**
    * The user IDs that were added
    */
-  members: string[];
+  members: Array<string>;
 
   custom: Record<string, any>;
 
@@ -28403,7 +28605,7 @@ export interface UserGroupMemberRemovedEvent {
   /**
    * The user IDs that were removed
    */
-  members: string[];
+  members: Array<string>;
 
   custom: Record<string, any>;
 
@@ -28434,7 +28636,7 @@ export interface UserGroupResponse {
 
   team_id?: string;
 
-  members?: UserGroupMember[];
+  members?: Array<UserGroupMember>;
 }
 
 export interface UserGroupUpdatedEvent {
@@ -28550,7 +28752,7 @@ export interface UserMutedEvent {
   /**
    * The target users that were muted
    */
-  target_users?: UserResponseCommonFields[];
+  target_users?: Array<UserResponseCommonFields>;
 
   target_user?: UserResponseCommonFields;
 }
@@ -28609,7 +28811,7 @@ export interface UserRequest {
   /**
    * List of teams the user belongs to
    */
-  teams?: string[];
+  teams?: Array<string>;
 
   /**
    * Custom user data
@@ -28667,12 +28869,12 @@ export interface UserResponse {
    */
   updated_at: Date;
 
-  blocked_user_ids: string[];
+  blocked_user_ids: Array<string>;
 
   /**
    * List of teams user is a part of
    */
-  teams: string[];
+  teams: Array<string>;
 
   /**
    * Custom data for this object
@@ -28718,7 +28920,7 @@ export interface UserResponse {
   /**
    * List of devices user is using
    */
-  devices?: DeviceResponse[];
+  devices?: Array<DeviceResponse>;
 
   privacy_settings?: PrivacySettingsResponse;
 
@@ -28742,9 +28944,9 @@ export interface UserResponseCommonFields {
 
   updated_at: Date;
 
-  blocked_user_ids: string[];
+  blocked_user_ids: Array<string>;
 
-  teams: string[];
+  teams: Array<string>;
 
   custom: Record<string, any>;
 
@@ -28780,9 +28982,9 @@ export interface UserResponsePrivacyFields {
 
   updated_at: Date;
 
-  blocked_user_ids: string[];
+  blocked_user_ids: Array<string>;
 
-  teams: string[];
+  teams: Array<string>;
 
   custom: Record<string, any>;
 
@@ -28888,7 +29090,7 @@ export interface UserUnmutedEvent {
   /**
    * The target users that were unmuted
    */
-  target_users?: UserResponseCommonFields[];
+  target_users?: Array<UserResponseCommonFields>;
 
   target_user?: UserResponseCommonFields;
 }
@@ -28954,7 +29156,7 @@ export interface VelocityFilterConfig {
 
   first_message_only?: boolean;
 
-  rules?: VelocityFilterConfigRule[];
+  rules?: Array<VelocityFilterConfigRule>;
 }
 
 export interface VelocityFilterConfigRule {
@@ -28990,15 +29192,15 @@ export interface VelocityFilterConfigRule {
 export interface VideoCallRuleConfig {
   flag_all_labels?: boolean;
 
-  flagged_labels?: string[];
+  flagged_labels?: Array<string>;
 
-  rules?: HarmConfig[];
+  rules?: Array<HarmConfig>;
 }
 
 export interface VideoContentParameters {
   label_operator?: string;
 
-  harm_labels?: string[];
+  harm_labels?: Array<string>;
 }
 
 export interface VideoEndCallRequestPayload {}
@@ -29006,7 +29208,7 @@ export interface VideoEndCallRequestPayload {}
 export interface VideoKickUserRequestPayload {}
 
 export interface VideoReactionOverTimeResponse {
-  by_minute?: CountByMinuteResponse[];
+  by_minute?: Array<CountByMinuteResponse>;
 }
 
 export interface VideoReactionResponse {
@@ -29033,7 +29235,7 @@ export interface VideoRuleParameters {
 
   time_window?: string;
 
-  harm_labels?: string[];
+  harm_labels?: Array<string>;
 }
 
 export interface VideoSettings {
@@ -29389,11 +29591,11 @@ export interface WrappedUnreadCountsResponse {
 
   total_unread_threads_count: number;
 
-  channel_type: UnreadCountsChannelType[];
+  channel_type: Array<UnreadCountsChannelType>;
 
-  channels: UnreadCountsChannel[];
+  channels: Array<UnreadCountsChannel>;
 
-  threads: UnreadCountsThread[];
+  threads: Array<UnreadCountsThread>;
 
   total_unread_count_by_team?: Record<string, number>;
 }

--- a/src/gen/moderation/ModerationApi.ts
+++ b/src/gen/moderation/ModerationApi.ts
@@ -110,7 +110,7 @@ export class ModerationApi {
       StreamResponse<GetActionConfigResponse>
     >('GET', '/api/v2/moderation/action_config', undefined, queryParams);
 
-    decoders.GetActionConfigResponse?.(response.body);
+    decoders['GetActionConfigResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -142,7 +142,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.UpsertActionConfigResponse?.(response.body);
+    decoders['UpsertActionConfigResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -167,7 +167,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.BulkUpsertActionConfigResponse?.(response.body);
+    decoders['BulkUpsertActionConfigResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -192,7 +192,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.BulkDeleteActionConfigResponse?.(response.body);
+    decoders['BulkDeleteActionConfigResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -217,7 +217,7 @@ export class ModerationApi {
       queryParams,
     );
 
-    decoders.DeleteActionConfigResponse?.(response.body);
+    decoders['DeleteActionConfigResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -247,7 +247,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.InsertActionLogResponse?.(response.body);
+    decoders['InsertActionLogResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -280,7 +280,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.AnalyzeResponse?.(response.body);
+    decoders['AnalyzeResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -309,7 +309,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.AppealResponse?.(response.body);
+    decoders['AppealResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -325,7 +325,7 @@ export class ModerationApi {
       StreamResponse<GetAppealResponse>
     >('GET', '/api/v2/moderation/appeal/{id}', pathParams, undefined);
 
-    decoders.GetAppealResponse?.(response.body);
+    decoders['GetAppealResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -354,7 +354,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.QueryAppealsResponse?.(response.body);
+    decoders['QueryAppealsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -385,7 +385,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.BulkActionAppealsResponse?.(response.body);
+    decoders['BulkActionAppealsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -416,7 +416,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.ModerationBanResponse?.(response.body);
+    decoders['ModerationBanResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -439,7 +439,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.BulkImageModerationResponse?.(response.body);
+    decoders['BulkImageModerationResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -463,7 +463,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.BypassResponse?.(response.body);
+    decoders['BypassResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -495,7 +495,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.CheckResponse?.(response.body);
+    decoders['CheckResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -518,7 +518,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.CheckS3AccessResponse?.(response.body);
+    decoders['CheckS3AccessResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -562,7 +562,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.UpsertConfigResponse?.(response.body);
+    decoders['UpsertConfigResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -584,7 +584,7 @@ export class ModerationApi {
       StreamResponse<DeleteModerationConfigResponse>
     >('DELETE', '/api/v2/moderation/config/{key}', pathParams, queryParams);
 
-    decoders.DeleteModerationConfigResponse?.(response.body);
+    decoders['DeleteModerationConfigResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -604,7 +604,7 @@ export class ModerationApi {
       StreamResponse<GetConfigResponse>
     >('GET', '/api/v2/moderation/config/{key}', pathParams, queryParams);
 
-    decoders.GetConfigResponse?.(response.body);
+    decoders['GetConfigResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -633,7 +633,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.QueryModerationConfigsResponse?.(response.body);
+    decoders['QueryModerationConfigsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -662,7 +662,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.CustomCheckResponse?.(response.body);
+    decoders['CustomCheckResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -679,7 +679,7 @@ export class ModerationApi {
       undefined,
     );
 
-    decoders.DeleteModerationTemplateResponse?.(response.body);
+    decoders['DeleteModerationTemplateResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -696,7 +696,7 @@ export class ModerationApi {
       undefined,
     );
 
-    decoders.QueryFeedModerationTemplatesResponse?.(response.body);
+    decoders['QueryFeedModerationTemplatesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -720,7 +720,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.UpsertModerationTemplateResponse?.(response.body);
+    decoders['UpsertModerationTemplateResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -748,7 +748,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.FlagItemResponse?.(response.body);
+    decoders['FlagItemResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -772,7 +772,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.GetFlagCountResponse?.(response.body);
+    decoders['GetFlagCountResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -799,7 +799,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.QueryModerationFlagsResponse?.(response.body);
+    decoders['QueryModerationFlagsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -828,7 +828,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.LabelsResponse?.(response.body);
+    decoders['LabelsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -857,7 +857,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.QueryLabelResultsResponse?.(response.body);
+    decoders['QueryLabelResultsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -886,7 +886,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.QueryModerationLogsResponse?.(response.body);
+    decoders['QueryModerationLogsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -922,7 +922,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.UpsertModerationRuleResponse?.(response.body);
+    decoders['UpsertModerationRuleResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -947,7 +947,7 @@ export class ModerationApi {
       queryParams,
     );
 
-    decoders.DeleteModerationRuleResponse?.(response.body);
+    decoders['DeleteModerationRuleResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -963,7 +963,7 @@ export class ModerationApi {
       StreamResponse<GetModerationRuleResponse>
     >('GET', '/api/v2/moderation/moderation_rule/{id}', pathParams, undefined);
 
-    decoders.GetModerationRuleResponse?.(response.body);
+    decoders['GetModerationRuleResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -992,7 +992,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.QueryModerationRulesResponse?.(response.body);
+    decoders['QueryModerationRulesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1016,7 +1016,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.MuteResponse?.(response.body);
+    decoders['MuteResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1037,7 +1037,7 @@ export class ModerationApi {
       undefined,
     );
 
-    decoders.PolicyTestRunResponse?.(response.body);
+    decoders['PolicyTestRunResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1049,7 +1049,7 @@ export class ModerationApi {
       StreamResponse<PolicyTestSetListResponse>
     >('GET', '/api/v2/moderation/policy_tests/sets', undefined, undefined);
 
-    decoders.PolicyTestSetListResponse?.(response.body);
+    decoders['PolicyTestSetListResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1077,7 +1077,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.PolicyTestSetResponse?.(response.body);
+    decoders['PolicyTestSetResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1096,7 +1096,7 @@ export class ModerationApi {
       undefined,
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1117,7 +1117,7 @@ export class ModerationApi {
       undefined,
     );
 
-    decoders.PolicyTestSetResponse?.(response.body);
+    decoders['PolicyTestSetResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1138,7 +1138,7 @@ export class ModerationApi {
       undefined,
     );
 
-    decoders.PolicyTestRunResponse?.(response.body);
+    decoders['PolicyTestRunResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1154,7 +1154,7 @@ export class ModerationApi {
       StreamResponse<ListQueuesResponse>
     >('GET', '/api/v2/moderation/queues', undefined, queryParams);
 
-    decoders.ListQueuesResponse?.(response.body);
+    decoders['ListQueuesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1183,7 +1183,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.QueueResponse?.(response.body);
+    decoders['QueueResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1203,7 +1203,7 @@ export class ModerationApi {
       StreamResponse<QueueResponse>
     >('GET', '/api/v2/moderation/queues/{id}', pathParams, queryParams);
 
-    decoders.QueueResponse?.(response.body);
+    decoders['QueueResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1234,7 +1234,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.QueueResponse?.(response.body);
+    decoders['QueueResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1261,7 +1261,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.QueueResponse?.(response.body);
+    decoders['QueueResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1295,7 +1295,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.QueryReviewQueueResponse?.(response.body);
+    decoders['QueryReviewQueueResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1311,7 +1311,7 @@ export class ModerationApi {
       StreamResponse<GetReviewQueueItemResponse>
     >('GET', '/api/v2/moderation/review_queue/{id}', pathParams, undefined);
 
-    decoders.GetReviewQueueItemResponse?.(response.body);
+    decoders['GetReviewQueueItemResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1321,7 +1321,7 @@ export class ModerationApi {
       StreamResponse<GetSetupSessionResponse>
     >('GET', '/api/v2/moderation/setup', undefined, undefined);
 
-    decoders.GetSetupSessionResponse?.(response.body);
+    decoders['GetSetupSessionResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1346,7 +1346,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.UpsertSetupSessionResponse?.(response.body);
+    decoders['UpsertSetupSessionResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1391,7 +1391,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.SubmitActionResponse?.(response.body);
+    decoders['SubmitActionResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1422,7 +1422,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.SubmitModerationFeedbackResponse?.(response.body);
+    decoders['SubmitModerationFeedbackResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1455,7 +1455,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.UnbanResponse?.(response.body);
+    decoders['UnbanResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1480,7 +1480,7 @@ export class ModerationApi {
       'application/json',
     );
 
-    decoders.UnmuteResponse?.(response.body);
+    decoders['UnmuteResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }

--- a/src/gen/video/VideoApi.ts
+++ b/src/gen/video/VideoApi.ts
@@ -125,7 +125,7 @@ export class VideoApi {
       StreamResponse<GetActiveCallsStatusResponse>
     >('GET', '/api/v2/video/active_calls_status', undefined, undefined);
 
-    decoders.GetActiveCallsStatusResponse?.(response.body);
+    decoders['GetActiveCallsStatusResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -155,7 +155,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.QueryUserFeedbackResponse?.(response.body);
+    decoders['QueryUserFeedbackResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -184,7 +184,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.QueryCallMembersResponse?.(response.body);
+    decoders['QueryCallMembersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -211,7 +211,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.QueryCallStatsResponse?.(response.body);
+    decoders['QueryCallStatsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -239,7 +239,7 @@ export class VideoApi {
       StreamResponse<GetCallResponse>
     >('GET', '/api/v2/video/call/{type}/{id}', pathParams, queryParams);
 
-    decoders.GetCallResponse?.(response.body);
+    decoders['GetCallResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -268,7 +268,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.UpdateCallResponse?.(response.body);
+    decoders['UpdateCallResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -299,7 +299,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.GetOrCreateCallResponse?.(response.body);
+    decoders['GetOrCreateCallResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -326,7 +326,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.BlockUserResponse?.(response.body);
+    decoders['BlockUserResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -361,7 +361,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.SendClosedCaptionResponse?.(response.body);
+    decoders['SendClosedCaptionResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -388,7 +388,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.DeleteCallResponse?.(response.body);
+    decoders['DeleteCallResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -417,7 +417,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.SendCallEventResponse?.(response.body);
+    decoders['SendCallEventResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -449,7 +449,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.CollectUserFeedbackResponse?.(response.body);
+    decoders['CollectUserFeedbackResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -484,7 +484,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.GoLiveResponse?.(response.body);
+    decoders['GoLiveResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -514,7 +514,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.KickUserResponse?.(response.body);
+    decoders['KickUserResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -537,7 +537,7 @@ export class VideoApi {
       undefined,
     );
 
-    decoders.EndCallResponse?.(response.body);
+    decoders['EndCallResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -565,7 +565,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.UpdateCallMembersResponse?.(response.body);
+    decoders['UpdateCallMembersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -599,7 +599,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.MuteUsersResponse?.(response.body);
+    decoders['MuteUsersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -633,7 +633,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.QueryCallParticipantsResponse?.(response.body);
+    decoders['QueryCallParticipantsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -661,7 +661,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.PinResponse?.(response.body);
+    decoders['PinResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -684,7 +684,7 @@ export class VideoApi {
       undefined,
     );
 
-    decoders.ListRecordingsResponse?.(response.body);
+    decoders['ListRecordingsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -716,7 +716,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.StartRecordingResponse?.(response.body);
+    decoders['StartRecordingResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -746,7 +746,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.StopRecordingResponse?.(response.body);
+    decoders['StopRecordingResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -768,7 +768,7 @@ export class VideoApi {
       StreamResponse<GetCallReportResponse>
     >('GET', '/api/v2/video/call/{type}/{id}/report', pathParams, queryParams);
 
-    decoders.GetCallReportResponse?.(response.body);
+    decoders['GetCallReportResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -796,7 +796,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.RingCallResponse?.(response.body);
+    decoders['RingCallResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -823,7 +823,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.StartRTMPBroadcastsResponse?.(response.body);
+    decoders['StartRTMPBroadcastsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -846,7 +846,7 @@ export class VideoApi {
       undefined,
     );
 
-    decoders.StopAllRTMPBroadcastsResponse?.(response.body);
+    decoders['StopAllRTMPBroadcastsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -876,7 +876,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.StopRTMPBroadcastsResponse?.(response.body);
+    decoders['StopRTMPBroadcastsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -911,7 +911,7 @@ export class VideoApi {
       queryParams,
     );
 
-    decoders.GetCallParticipantSessionMetricsResponse?.(response.body);
+    decoders['GetCallParticipantSessionMetricsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -946,7 +946,7 @@ export class VideoApi {
       queryParams,
     );
 
-    decoders.QueryCallParticipantSessionsResponse?.(response.body);
+    decoders['QueryCallParticipantSessionsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -969,7 +969,7 @@ export class VideoApi {
       undefined,
     );
 
-    decoders.StartHLSBroadcastingResponse?.(response.body);
+    decoders['StartHLSBroadcastingResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -999,7 +999,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.StartClosedCaptionsResponse?.(response.body);
+    decoders['StartClosedCaptionsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1026,7 +1026,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.StartFrameRecordingResponse?.(response.body);
+    decoders['StartFrameRecordingResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1055,7 +1055,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.StartTranscriptionResponse?.(response.body);
+    decoders['StartTranscriptionResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1078,7 +1078,7 @@ export class VideoApi {
       undefined,
     );
 
-    decoders.StopHLSBroadcastingResponse?.(response.body);
+    decoders['StopHLSBroadcastingResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1105,7 +1105,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.StopClosedCaptionsResponse?.(response.body);
+    decoders['StopClosedCaptionsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1128,7 +1128,7 @@ export class VideoApi {
       undefined,
     );
 
-    decoders.StopFrameRecordingResponse?.(response.body);
+    decoders['StopFrameRecordingResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1162,7 +1162,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.StopLiveResponse?.(response.body);
+    decoders['StopLiveResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1189,7 +1189,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.StopTranscriptionResponse?.(response.body);
+    decoders['StopTranscriptionResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1212,7 +1212,7 @@ export class VideoApi {
       undefined,
     );
 
-    decoders.ListTranscriptionsResponse?.(response.body);
+    decoders['ListTranscriptionsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1239,7 +1239,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.UnblockUserResponse?.(response.body);
+    decoders['UnblockUserResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1267,7 +1267,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.UnpinResponse?.(response.body);
+    decoders['UnpinResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1296,7 +1296,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.UpdateUserPermissionsResponse?.(response.body);
+    decoders['UpdateUserPermissionsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1323,7 +1323,7 @@ export class VideoApi {
       undefined,
     );
 
-    decoders.DeleteRecordingResponse?.(response.body);
+    decoders['DeleteRecordingResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1350,7 +1350,7 @@ export class VideoApi {
       undefined,
     );
 
-    decoders.DeleteTranscriptionResponse?.(response.body);
+    decoders['DeleteTranscriptionResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1373,7 +1373,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.ReportClientEventResponse?.(response.body);
+    decoders['ReportClientEventResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1400,7 +1400,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.QueryCallSessionStatsResponse?.(response.body);
+    decoders['QueryCallSessionStatsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1437,7 +1437,7 @@ export class VideoApi {
       queryParams,
     );
 
-    decoders.QueryCallStatsMapResponse?.(response.body);
+    decoders['QueryCallStatsMapResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1474,7 +1474,7 @@ export class VideoApi {
       queryParams,
     );
 
-    decoders.GetCallSessionParticipantStatsDetailsResponse?.(response.body);
+    decoders['GetCallSessionParticipantStatsDetailsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1486,7 +1486,7 @@ export class VideoApi {
     limit?: number;
     prev?: string;
     next?: string;
-    sort?: SortParamRequest[];
+    sort?: Array<SortParamRequest>;
     filter_conditions?: Record<string, any>;
   }): Promise<StreamResponse<QueryCallSessionParticipantStatsResponse>> {
     const queryParams = {
@@ -1511,7 +1511,7 @@ export class VideoApi {
       queryParams,
     );
 
-    decoders.QueryCallSessionParticipantStatsResponse?.(response.body);
+    decoders['QueryCallSessionParticipantStatsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1524,7 +1524,7 @@ export class VideoApi {
     user_session: string;
     start_time?: string;
     end_time?: string;
-    severity?: string[];
+    severity?: Array<string>;
   }): Promise<
     StreamResponse<QueryCallSessionParticipantStatsTimelineResponse>
   > {
@@ -1550,7 +1550,9 @@ export class VideoApi {
       queryParams,
     );
 
-    decoders.QueryCallSessionParticipantStatsTimelineResponse?.(response.body);
+    decoders['QueryCallSessionParticipantStatsTimelineResponse']?.(
+      response.body,
+    );
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1577,7 +1579,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.QueryCallsResponse?.(response.body);
+    decoders['QueryCallsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1587,7 +1589,7 @@ export class VideoApi {
       StreamResponse<ListCallTypeResponse>
     >('GET', '/api/v2/video/calltypes', undefined, undefined);
 
-    decoders.ListCallTypeResponse?.(response.body);
+    decoders['ListCallTypeResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1614,7 +1616,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.CreateCallTypeResponse?.(response.body);
+    decoders['CreateCallTypeResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1633,7 +1635,7 @@ export class VideoApi {
       undefined,
     );
 
-    decoders.Response?.(response.body);
+    decoders['Response']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1649,7 +1651,7 @@ export class VideoApi {
       StreamResponse<GetCallTypeResponse>
     >('GET', '/api/v2/video/calltypes/{name}', pathParams, undefined);
 
-    decoders.GetCallTypeResponse?.(response.body);
+    decoders['GetCallTypeResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1678,7 +1680,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.UpdateCallTypeResponse?.(response.body);
+    decoders['UpdateCallTypeResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1688,7 +1690,7 @@ export class VideoApi {
       StreamResponse<GetEdgesResponse>
     >('GET', '/api/v2/video/edges', undefined, undefined);
 
-    decoders.GetEdgesResponse?.(response.body);
+    decoders['GetEdgesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1714,7 +1716,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.ResolveSipAuthResponse?.(response.body);
+    decoders['ResolveSipAuthResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1726,7 +1728,7 @@ export class VideoApi {
       StreamResponse<ListSIPInboundRoutingRuleResponse>
     >('GET', '/api/v2/video/sip/inbound_routing_rules', undefined, undefined);
 
-    decoders.ListSIPInboundRoutingRuleResponse?.(response.body);
+    decoders['ListSIPInboundRoutingRuleResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1757,7 +1759,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.SIPInboundRoutingRuleResponse?.(response.body);
+    decoders['SIPInboundRoutingRuleResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1778,7 +1780,7 @@ export class VideoApi {
       undefined,
     );
 
-    decoders.DeleteSIPInboundRoutingRuleResponse?.(response.body);
+    decoders['DeleteSIPInboundRoutingRuleResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1812,7 +1814,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.UpdateSIPInboundRoutingRuleResponse?.(response.body);
+    decoders['UpdateSIPInboundRoutingRuleResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1822,7 +1824,7 @@ export class VideoApi {
       StreamResponse<ListSIPTrunksResponse>
     >('GET', '/api/v2/video/sip/inbound_trunks', undefined, undefined);
 
-    decoders.ListSIPTrunksResponse?.(response.body);
+    decoders['ListSIPTrunksResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1848,7 +1850,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.CreateSIPTrunkResponse?.(response.body);
+    decoders['CreateSIPTrunkResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1864,7 +1866,7 @@ export class VideoApi {
       StreamResponse<DeleteSIPTrunkResponse>
     >('DELETE', '/api/v2/video/sip/inbound_trunks/{id}', pathParams, undefined);
 
-    decoders.DeleteSIPTrunkResponse?.(response.body);
+    decoders['DeleteSIPTrunkResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1893,7 +1895,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.UpdateSIPTrunkResponse?.(response.body);
+    decoders['UpdateSIPTrunkResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1921,7 +1923,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.ResolveSipInboundResponse?.(response.body);
+    decoders['ResolveSipInboundResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1946,7 +1948,7 @@ export class VideoApi {
       'application/json',
     );
 
-    decoders.QueryAggregateCallStatsResponse?.(response.body);
+    decoders['QueryAggregateCallStatsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
@@ -1964,7 +1966,7 @@ export class VideoApi {
       StreamResponse<GetDailyDigestResponse>
     >('GET', '/api/v2/video/stats/daily_digest', undefined, queryParams);
 
-    decoders.GetDailyDigestResponse?.(response.body);
+    decoders['GetDailyDigestResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }


### PR DESCRIPTION
Regenerates the client from the `chat` serverside spec at **v235.20.1** (previously v235.16.3, #328). Generated from the `chat` working tree at `v235.20.1-91-g6c6373e6cd`, so it also picks up spec changes merged after that tag.

## Chat: pinned messages

- `ChatApi.getPinnedMessages` — `GET /chat/channels/{type}/{id}/pinned_messages`, with both id and `pinned_at` cursor pagination (`id_gt`/`id_gte`/`id_lt`/`id_lte`/`id_around`, `pinned_at_after`/`pinned_at_after_or_equal`/`pinned_at_before`/`pinned_at_before_or_equal`/`pinned_at_around`), plus `limit`, `offset`, `sort`, `member_custom_include` and `user_id`.
- `Channel.getPinnedMessages` convenience wrapper on `ChannelApi`.
- Model: `GetPinnedMessagesResponse` (`messages: MessageResponse[]`).

## Chat: predefined filters

Named, server-stored filters for `QueryChannels`:

- `ChatApi.createPredefinedFilter` — `POST /chat/predefined_filters`
- `ChatApi.getPredefinedFilters` — `GET /chat/predefined_filters` (optional `include_stats`, `sort`)
- `ChatApi.getPredefinedFilter` / `updatePredefinedFilter` / `deletePredefinedFilter` — `GET|PUT|DELETE /chat/predefined_filters/{name}`

Models: `CreatePredefinedFilterRequest`, `CreatePredefinedFilterResponse`, `UpdatePredefinedFilterRequest`, `UpdatePredefinedFilterResponse`, `GetPredefinedFilterResponse`, `QueryPredefinedFiltersResponse`, `PredefinedFilterResponse`, `PredefinedFilterStatsResponse` (`calls`, `max_latency_ms`, `last_seen`), `PerformanceAnalysisResponse` (index/scan analysis with `score`, `recommendations`, `unindexed_fields`, `unindexed_sort_fields`, `warnings`), `SortParam`.

## Permissions: custom permission CRUD

- `CommonApi.createPermission` — `POST /permissions`
- `CommonApi.updatePermission` — `PUT /permissions/{id}`
- `CommonApi.deletePermission` — `DELETE /permissions/{id}`

Model: `PermissionRequest` (`action`, `name`, `description`, `owner`, `same_team`, `condition`). `getPermission` and `listPermissions` already existed.

## Other additions

- `getOrCreateChannel` (`ChatApi` and `ChannelApi`) accepts `user_id`.
- `QueryTeamUsageStatsRequest.team` — filter results to a single team ID; empty string selects users not assigned to any team; mutually exclusive with `next`.
- `ModerationPayload.other_media` and `ModerationPayloadResponse.other_media` — media URLs from attachments outside the typed image/video/audio lists (custom attachment types such as GIF pickers).

## Documentation-only spec changes

- The moderation `restore` action is now documented as state-aware: it reverses whichever of a delete, a block, or a shadow block currently applies (including both at once). `unblock` is marked deprecated in favour of it.
- `push_types` is clarified as an allowlist — empty or omitted means no types trigger push.

## Codegen churn (no behaviour change)

Most of the diff is the generator's output style changing:

- `T[]` → `Array<T>` in model and request types
- `decoders.X` → `decoders['X']`
- `Record<string, any>` → `{ [key: string]: any }` in decoder signatures

Normalizing those three patterns away shrinks the diff from ~4,450 changed lines to ~500, all accounted for above. `FeedsApi` and `ModerationApi` have no semantic change at all; `VideoApi` only reflows one call.

## ⚠️ Breaking changes

None. No endpoints, models, or fields were removed, no signatures changed, and no optionality changed.

## Verification

- `yarn lint` — clean
- `yarn build` — succeeds (vite bundles + `tsc --emitDeclarationOnly`)
