### PR TITLE
feat: feed counts endpoint

### DIFF
--- a/src/gen/chat/ChatApi.ts
+++ b/src/gen/chat/ChatApi.ts
@@ -1325,6 +1325,7 @@ export class ChatApi {
       custom_events: request?.custom_events,
       delivery_events: request?.delivery_events,
       mark_messages_pending: request?.mark_messages_pending,
+      message_retention: request?.message_retention,
       mutes: request?.mutes,
       partition_size: request?.partition_size,
       partition_ttl: request?.partition_ttl,

--- a/src/gen/common/CommonApi.ts
+++ b/src/gen/common/CommonApi.ts
@@ -25,6 +25,7 @@ import {
   CreateImportURLResponse,
   CreateImportV2TaskRequest,
   CreateImportV2TaskResponse,
+  CreatePermissionRequest,
   CreatePollOptionRequest,
   CreatePollRequest,
   CreateRoleRequest,
@@ -917,15 +918,16 @@ export class CommonApi {
   }
 
   async createPermission(
-    request: PermissionRequest,
+    request: CreatePermissionRequest,
   ): Promise<StreamResponse<Response>> {
     const body = {
       action: request?.action,
+      id: request?.id,
       name: request?.name,
+      condition: request?.condition,
       description: request?.description,
       owner: request?.owner,
       same_team: request?.same_team,
-      condition: request?.condition,
     };
 
     const response = await this.apiClient.sendRequest<StreamResponse<Response>>(
@@ -986,10 +988,10 @@ export class CommonApi {
     const body = {
       action: request?.action,
       name: request?.name,
+      condition: request?.condition,
       description: request?.description,
       owner: request?.owner,
       same_team: request?.same_team,
-      condition: request?.condition,
     };
 
     const response = await this.apiClient.sendRequest<StreamResponse<Response>>(

--- a/src/gen/feeds/FeedApi.ts
+++ b/src/gen/feeds/FeedApi.ts
@@ -5,6 +5,7 @@ import {
   ChangeFeedVisibilityRequest,
   ChangeFeedVisibilityResponse,
   DeleteFeedResponse,
+  GetFeedCountsResponse,
   GetOrCreateFeedRequest,
   GetOrCreateFeedResponse,
   MarkActivityRequest,
@@ -104,6 +105,13 @@ export class FeedApi {
       feed_id: this.id,
       feed_group_id: this.group,
       ...request,
+    });
+  }
+
+  getFeedCounts(): Promise<StreamResponse<GetFeedCountsResponse>> {
+    return this.feedsApi.getFeedCounts({
+      feed_id: this.id,
+      feed_group_id: this.group,
     });
   }
 

--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -62,6 +62,7 @@ import {
   GetCommentRepliesResponse,
   GetCommentResponse,
   GetCommentsResponse,
+  GetFeedCountsResponse,
   GetFeedGroupResponse,
   GetFeedViewResponse,
   GetFeedVisibilityResponse,
@@ -1981,6 +1982,29 @@ export class FeedsApi {
     );
 
     decoders['ChangeFeedVisibilityResponse']?.(response.body);
+
+    return { ...response.body, metadata: response.metadata };
+  }
+
+  async getFeedCounts(request: {
+    feed_group_id: string;
+    feed_id: string;
+  }): Promise<StreamResponse<GetFeedCountsResponse>> {
+    const pathParams = {
+      feed_group_id: request?.feed_group_id,
+      feed_id: request?.feed_id,
+    };
+
+    const response = await this.apiClient.sendRequest<
+      StreamResponse<GetFeedCountsResponse>
+    >(
+      'GET',
+      '/api/v2/feeds/feed_groups/{feed_group_id}/feeds/{feed_id}/counts',
+      pathParams,
+      undefined,
+    );
+
+    decoders['GetFeedCountsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -5419,6 +5419,8 @@ export interface ChannelConfig {
 
   max_message_length: number;
 
+  message_retention: string;
+
   mutes: boolean;
 
   name: string;
@@ -5569,6 +5571,8 @@ export interface ChannelConfigWithInfo {
   mark_messages_pending: boolean;
 
   max_message_length: number;
+
+  message_retention: string;
 
   mutes: boolean;
 
@@ -6571,6 +6575,8 @@ export interface ChannelTypeConfig {
 
   max_message_length: number;
 
+  message_retention: string;
+
   mutes: boolean;
 
   name: string;
@@ -7381,6 +7387,8 @@ export interface Classification {
   confidence?: number;
 
   severity?: string;
+
+  matched_contributors?: Array<string>;
 
   subclassifications?: Array<Classification>;
 }
@@ -8543,6 +8551,8 @@ export interface CreateChannelTypeResponse {
 
   max_message_length: number;
 
+  message_retention: string;
+
   mutes: boolean;
 
   name: string;
@@ -8955,6 +8965,43 @@ export interface CreateMembershipLevelResponse {
   duration: string;
 
   membership_level: MembershipLevelResponse;
+}
+
+export interface CreatePermissionRequest {
+  /**
+   * Action name this permission is for (e.g. SendMessage)
+   */
+  action: string;
+
+  /**
+   * Unique permission ID
+   */
+  id: string;
+
+  /**
+   * Name of the permission
+   */
+  name: string;
+
+  /**
+   * MongoDB style condition which decides whether or not the permission is granted
+   */
+  condition: Record<string, any>;
+
+  /**
+   * Description of the permission
+   */
+  description?: string;
+
+  /**
+   * Whether this permission applies to resource owner or not
+   */
+  owner?: boolean;
+
+  /**
+   * Whether this permission applies to teammates (multi-tenancy mode only)
+   */
+  same_team?: boolean;
 }
 
 export interface CreatePolicyTestSetRequest {
@@ -12973,6 +13020,8 @@ export interface GetChannelTypeResponse {
 
   max_message_length: number;
 
+  message_retention: string;
+
   mutes: boolean;
 
   name: string;
@@ -13186,6 +13235,25 @@ export interface GetExternalStorageResponse {
   aws_s3?: GetExternalStorageAWSS3Response;
 
   gcs?: GetExternalStorageGCSResponse;
+}
+
+export interface GetFeedCountsResponse {
+  /**
+   * Number of activities in the feed
+   */
+  activity_count: number;
+
+  /**
+   * Total number of comments on those activities, including nested replies
+   */
+  comment_count: number;
+
+  duration: string;
+
+  /**
+   * Sum of activity_count and comment_count
+   */
+  total_count: number;
 }
 
 export interface GetFeedGroupResponse {
@@ -18473,6 +18541,11 @@ export interface PermissionRequest {
   name: string;
 
   /**
+   * MongoDB style condition which decides whether or not the permission is granted
+   */
+  condition: Record<string, any>;
+
+  /**
    * Description of the permission
    */
   description?: string;
@@ -18486,11 +18559,6 @@ export interface PermissionRequest {
    * Whether this permission applies to teammates (multi-tenancy mode only)
    */
   same_team?: boolean;
-
-  /**
-   * MongoDB style condition which decides whether or not the permission is granted
-   */
-  condition?: Record<string, any>;
 }
 
 export interface PermissionRequestEvent {
@@ -26612,6 +26680,8 @@ export interface UpdateChannelTypeRequest {
 
   mark_messages_pending?: boolean;
 
+  message_retention?: string;
+
   mutes?: boolean;
 
   partition_size?: number;
@@ -26689,6 +26759,8 @@ export interface UpdateChannelTypeResponse {
   mark_messages_pending: boolean;
 
   max_message_length: number;
+
+  message_retention: string;
 
   mutes: boolean;
 


### PR DESCRIPTION
API endpoint for total count of activities + comments (incl. nested) in a feed