### PR TITLE
feat: add activity processor tag extraction thresholds

### DIFF
--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -595,6 +595,16 @@ export interface ActivityProcessorConfig {
    * Type of activity processor (required)
    */
   type: string;
+
+  /**
+   * Minimum number of characters the activity text must have before this processor runs. 0 (the default) disables the check. Only applies to text_interest_tags.
+   */
+  min_text_length?: number;
+
+  /**
+   * Minimum number of words the activity text must have before this processor runs. 0 (the default) disables the check. Only applies to text_interest_tags.
+   */
+  min_word_count?: number;
 }
 
 export interface ActivityReactionAddedEvent {


### PR DESCRIPTION
## Ticket
- https://linear.app/stream/issue/FEEDS-1792/make-activity-processor-tag-extraction-thresholds-configurable

## Summary

Regenerates `src/gen` from the chat OpenAPI spec to pick up two new optional fields on `ActivityProcessorConfig`:

```ts
min_text_length?: number;
min_word_count?: number;
```

They let a feed group gate `text_interest_tags` extraction on how much text an activity actually has. Today there is no gate at all — a one-character activity triggers a full LLM call and whatever topics the model invents land in `interest_tags`, which is what a customer reported as junk tags. Both fields default to `0` (disabled), so existing behaviour is unchanged and the knob is opt-in.

## Notes for review

**Branch name matches the chat branch on purpose.** `tests/qa/Makefile` resolves `VIDEO_JS_SERVER_SDK_BRANCH` by looking for a `stream-node` branch with the same name as the chat branch, and swaps `@stream-io/node-sdk` to it for the QA run. That is how [GetStream/chat#16074](https://github.com/GetStream/chat/pull/16074)'s QA tests exercise `min_text_length` / `min_word_count` before this SDK is released. (This PR supersedes #338, which sat on a non-matching branch name.)


The regeneration diff is **only** those 10 lines — `src/gen` was already in sync with master, so nothing unrelated came along.

Both fields are optional, so this is additive and backwards compatible: existing callers constructing an `ActivityProcessorConfig` keep compiling untouched.

## Verification

- `yarn generate:open-api` — regenerated, diff scoped to `ActivityProcessorConfig`
- `yarn build` — clean
- `yarn lint` — clean, no new warnings
- `yarn test` — 18 failed / 3 passed / 3 skipped, **identical to `main`**. Every failure is `secretOrPrivateKey must have a value` from missing `STREAM_API_SECRET` locally; verified by stashing the change and re-running. A type-only addition cannot affect these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
