### PR TITLE
feat: add default_follower_role to feed group API

### DIFF
--- a/src/gen/chat/ChatApi.ts
+++ b/src/gen/chat/ChatApi.ts
@@ -17,6 +17,7 @@ import {
   CreatePredefinedFilterRequest,
   CreatePredefinedFilterResponse,
   CreateReminderRequest,
+  CreateReminderResponse,
   CreateSegmentRequest,
   CreateSegmentResponse,
   DeleteCampaignResponse,
@@ -94,7 +95,6 @@ import {
   QueryTeamUsageStatsResponse,
   QueryThreadsRequest,
   QueryThreadsResponse,
-  ReminderResponseData,
   Response,
   SearchPayload,
   SearchResponse,
@@ -2028,7 +2028,7 @@ export class ChatApi {
 
   async createReminder(
     request: CreateReminderRequest & { message_id: string },
-  ): Promise<StreamResponse<ReminderResponseData>> {
+  ): Promise<StreamResponse<CreateReminderResponse>> {
     const pathParams = {
       message_id: request?.message_id,
     };
@@ -2039,7 +2039,7 @@ export class ChatApi {
     };
 
     const response = await this.apiClient.sendRequest<
-      StreamResponse<ReminderResponseData>
+      StreamResponse<CreateReminderResponse>
     >(
       'POST',
       '/api/v2/chat/messages/{message_id}/reminders',
@@ -2049,7 +2049,7 @@ export class ChatApi {
       'application/json',
     );
 
-    decoders['ReminderResponseData']?.(response.body);
+    decoders['CreateReminderResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }

--- a/src/gen/common/CommonApi.ts
+++ b/src/gen/common/CommonApi.ts
@@ -156,6 +156,8 @@ export class CommonApi {
       image_moderation_enabled: request?.image_moderation_enabled,
       max_aggregated_activities_length:
         request?.max_aggregated_activities_length,
+      member_custom_on_mentioned_users_enabled:
+        request?.member_custom_on_mentioned_users_enabled,
       member_custom_on_messages_enabled:
         request?.member_custom_on_messages_enabled,
       migrate_permissions_to_v2: request?.migrate_permissions_to_v2,

--- a/src/gen/feeds/FeedsApi.ts
+++ b/src/gen/feeds/FeedsApi.ts
@@ -1715,6 +1715,7 @@ export class FeedsApi {
   ): Promise<StreamResponse<CreateFeedGroupResponse>> {
     const body = {
       id: request?.id,
+      default_follower_role: request?.default_follower_role,
       default_visibility: request?.default_visibility,
       activity_processors: request?.activity_processors,
       activity_selectors: request?.activity_selectors,
@@ -2275,6 +2276,7 @@ export class FeedsApi {
       id: request?.id,
     };
     const body = {
+      default_follower_role: request?.default_follower_role,
       default_visibility: request?.default_visibility,
       activity_processors: request?.activity_processors,
       activity_selectors: request?.activity_selectors,
@@ -2310,6 +2312,7 @@ export class FeedsApi {
       id: request?.id,
     };
     const body = {
+      default_follower_role: request?.default_follower_role,
       default_visibility: request?.default_visibility,
       activity_processors: request?.activity_processors,
       activity_selectors: request?.activity_selectors,
@@ -2521,6 +2524,7 @@ export class FeedsApi {
   ): Promise<StreamResponse<CreateFeedsBatchResponse>> {
     const body = {
       feeds: request?.feeds,
+      create_users: request?.create_users,
       enrich_own_fields: request?.enrich_own_fields,
     };
 

--- a/src/gen/model-decoders/decoders.ts
+++ b/src/gen/model-decoders/decoders.ts
@@ -2150,6 +2150,13 @@ decoders['CreatePredefinedFilterResponse'] = (input?: {
   return decode(typeMappings, input);
 };
 
+decoders['CreateReminderResponse'] = (input?: { [key: string]: any }) => {
+  const typeMappings: TypeMapping = {
+    reminder: { type: 'ReminderResponseData', isSingle: true },
+  };
+  return decode(typeMappings, input);
+};
+
 decoders['CreateRoleResponse'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     role: { type: 'Role', isSingle: true },
@@ -4844,9 +4851,9 @@ decoders['ReminderCreatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
-    received_at: { type: 'DatetimeType', isSingle: true },
-
     reminder: { type: 'ReminderResponseData', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
@@ -4855,9 +4862,9 @@ decoders['ReminderDeletedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
-    received_at: { type: 'DatetimeType', isSingle: true },
-
     reminder: { type: 'ReminderResponseData', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
@@ -4866,9 +4873,9 @@ decoders['ReminderNotificationEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
-    received_at: { type: 'DatetimeType', isSingle: true },
-
     reminder: { type: 'ReminderResponseData', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };
@@ -4894,9 +4901,9 @@ decoders['ReminderUpdatedEvent'] = (input?: { [key: string]: any }) => {
   const typeMappings: TypeMapping = {
     created_at: { type: 'DatetimeType', isSingle: true },
 
-    received_at: { type: 'DatetimeType', isSingle: true },
-
     reminder: { type: 'ReminderResponseData', isSingle: true },
+
+    received_at: { type: 'DatetimeType', isSingle: true },
   };
   return decode(typeMappings, input);
 };

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -210,7 +210,7 @@ export interface AcceptFollowRequest {
   target: string;
 
   /**
-   * Optional role for the follower in the follow relationship
+   * Optional role for the follower in the follow relationship. Server-side only, and one of 'feed_follower' (the default) or 'feed_member_viewer'.
    */
   follower_role?: string;
 }
@@ -602,7 +602,7 @@ export interface ActivityProcessorConfig {
   min_text_length?: number;
 
   /**
-   * Minimum number of words the activity text must have before this processor runs. 0 (the default) disables the check. Only applies to text_interest_tags.
+   * Minimum number of words the activity text must have before this processor runs. 0 (the default) disables the check. Only applies to text_interest_tags. Words are whitespace-separated, so scripts written without word spacing (Chinese, Japanese, Thai) always count as 1 word regardless of length — use min_text_length for those.
    */
   min_word_count?: number;
 }
@@ -1935,6 +1935,8 @@ export interface AppResponseFields {
   image_moderation_enabled: boolean;
 
   max_aggregated_activities_length: number;
+
+  member_custom_on_mentioned_users_enabled: boolean;
 
   member_custom_on_messages_enabled: boolean;
 
@@ -6020,19 +6022,16 @@ export interface ChannelMemberPartialResponse {
 }
 
 export interface ChannelMemberRequest {
-  user_id: string;
-
   /**
    * Role of the member in the channel
    */
   channel_role?: string;
 
+  user_id?: string;
+
   custom?: Record<string, any>;
 
-  /**
-   * User response object
-   */
-  user?: UserResponse;
+  user?: MemberUserRequest;
 }
 
 export interface ChannelMemberResponse {
@@ -8765,6 +8764,8 @@ export interface CreateFeedGroupRequest {
    */
   id: string;
 
+  default_follower_role?: string;
+
   /**
    * Default visibility for the feed group, can be 'public', 'visible', 'followers', 'members', or 'private'. Defaults to 'visible' if not provided.
    */
@@ -8833,6 +8834,11 @@ export interface CreateFeedsBatchRequest {
    * List of feeds to create
    */
   feeds: Array<FeedRequest>;
+
+  /**
+   * Server-side only. If true, auto-creates users referenced by feeds[].created_by_id that don't already exist. Default: false.
+   */
+  create_users?: boolean;
 
   /**
    * If true, enriches the created feeds with own_* fields (own_follows, own_followings, own_capabilities, own_membership). Defaults to false for performance.
@@ -9176,6 +9182,15 @@ export interface CreateReminderRequest {
    * User request object
    */
   user?: UserRequest;
+}
+
+export interface CreateReminderResponse {
+  /**
+   * Duration of the request in milliseconds
+   */
+  duration: string;
+
+  reminder: ReminderResponseData;
 }
 
 export interface CreateRoleRequest {
@@ -11054,6 +11069,8 @@ export interface FeedGroup {
 
   created_at: Date;
 
+  default_follower_role: string;
+
   default_visibility: string;
 
   group_id: string;
@@ -11147,6 +11164,11 @@ export interface FeedGroupResponse {
    * When the feed group was last updated
    */
   updated_at: Date;
+
+  /**
+   * Role new followers of feeds in this group are given. One of: feed_follower, feed_member_viewer. Empty means feed_follower. Applied when the follow is accepted, so a follow that starts pending picks it up on approval
+   */
+  default_follower_role?: string;
 
   /**
    * Default visibility for activities. One of: public, visible, followers, members, private
@@ -12613,7 +12635,7 @@ export interface FollowResponse {
   created_at: Date;
 
   /**
-   * Role of the follower (source user) in the follow relationship
+   * Role of the follower (source user) in the follow relationship, as stored. A value outside the allowed set is reported as stored but evaluated as 'feed_follower'.
    */
   follower_role: string;
 
@@ -13524,6 +13546,8 @@ export interface GetOrCreateCallResponse {
 }
 
 export interface GetOrCreateFeedGroupRequest {
+  default_follower_role?: string;
+
   /**
    * Default visibility for the feed group, can be 'public', 'visible', 'followers', 'members', or 'private'. Defaults to 'visible' if not provided.
    */
@@ -15620,6 +15644,28 @@ export interface MemberUpdatedEvent {
   user?: UserResponseCommonFields;
 }
 
+export interface MemberUserRequest {
+  id: string;
+
+  image?: string;
+
+  invisible?: boolean;
+
+  language?: string;
+
+  name?: string;
+
+  role?: string;
+
+  teams?: Array<string>;
+
+  custom?: Record<string, any>;
+
+  privacy_settings?: PrivacySettingsResponse;
+
+  teams_role?: Record<string, string>;
+}
+
 export interface MembersResponse {
   /**
    * Duration of the request in milliseconds
@@ -16481,6 +16527,11 @@ export interface MessageResponse {
 
   member?: ChannelMemberPartialResponse;
 
+  /**
+   * Channel member data for the users mentioned in the message, keyed by user id. Only present when the app has member custom on mentioned users enabled, and only for the first two mentioned users of each message
+   */
+  mentioned_channel_members?: Record<string, ChannelMemberPartialResponse>;
+
   moderation?: ModerationV2Response;
 
   /**
@@ -16850,6 +16901,11 @@ export interface MessageWithChannelResponse {
   image_labels?: Record<string, Array<string>>;
 
   member?: ChannelMemberPartialResponse;
+
+  /**
+   * Channel member data for the users mentioned in the message, keyed by user id. Only present when the app has member custom on mentioned users enabled, and only for the first two mentioned users of each message
+   */
+  mentioned_channel_members?: Record<string, ChannelMemberPartialResponse>;
 
   moderation?: ModerationV2Response;
 
@@ -18938,7 +18994,11 @@ export interface PollResponseData {
 
   vote_count: number;
 
-  voting_visibility: string;
+  /**
+   * Voting visibility of the poll
+   */
+
+  voting_visibility: 'anonymous' | 'public';
 
   latest_answers: Array<PollVoteResponseData>;
 
@@ -20610,11 +20670,6 @@ export interface QueryLabelResultsResponse {
 export interface QueryMembersPayload {
   type: string;
 
-  /**
-   * Filter conditions to apply to the query
-   */
-  filter_conditions: Record<string, any>;
-
   id?: string;
 
   limit?: number;
@@ -20629,6 +20684,11 @@ export interface QueryMembersPayload {
    * Array of sort parameters
    */
   sort?: Array<SortParamRequest>;
+
+  /**
+   * Filter conditions to apply to the query
+   */
+  filter_conditions?: Record<string, any>;
 
   /**
    * User request object
@@ -22170,6 +22230,8 @@ export interface ReminderCreatedEvent {
 
   custom: Record<string, any>;
 
+  reminder: ReminderResponseData;
+
   /**
    * The type of event: "reminder.created" in this case
    */
@@ -22181,8 +22243,6 @@ export interface ReminderCreatedEvent {
   parent_id?: string;
 
   received_at?: Date;
-
-  reminder?: ReminderResponseData;
 }
 
 export interface ReminderDeletedEvent {
@@ -22208,6 +22268,8 @@ export interface ReminderDeletedEvent {
 
   custom: Record<string, any>;
 
+  reminder: ReminderResponseData;
+
   /**
    * The type of event: "reminder.deleted" in this case
    */
@@ -22219,8 +22281,6 @@ export interface ReminderDeletedEvent {
   parent_id?: string;
 
   received_at?: Date;
-
-  reminder?: ReminderResponseData;
 }
 
 export interface ReminderNotificationEvent {
@@ -22246,6 +22306,8 @@ export interface ReminderNotificationEvent {
 
   custom: Record<string, any>;
 
+  reminder: ReminderResponseData;
+
   /**
    * The type of event: "notification.reminder_due" in this case
    */
@@ -22254,8 +22316,6 @@ export interface ReminderNotificationEvent {
   parent_id?: string;
 
   received_at?: Date;
-
-  reminder?: ReminderResponseData;
 }
 
 export interface ReminderResponseData {
@@ -22310,6 +22370,8 @@ export interface ReminderUpdatedEvent {
 
   custom: Record<string, any>;
 
+  reminder: ReminderResponseData;
+
   /**
    * The type of event: "reminder.updated" in this case
    */
@@ -22321,8 +22383,6 @@ export interface ReminderUpdatedEvent {
   parent_id?: string;
 
   received_at?: Date;
-
-  reminder?: ReminderResponseData;
 }
 
 export interface RemoveUserGroupMembersRequest {
@@ -23635,6 +23695,8 @@ export interface SearchResultMessage {
   image_labels?: Record<string, Array<string>>;
 
   member?: ChannelMemberPartialResponse;
+
+  mentioned_channel_members?: Record<string, ChannelMemberPartialResponse>;
 
   moderation?: ModerationV2Response;
 
@@ -25692,7 +25754,8 @@ export interface UnbanActionRequestPayload {
 
 export interface UnbanRequest {
   /**
-   * ID of the user performing the unban
+   * @deprecated
+   * ID of the user performing the unban Deprecated: not used by the unban flow
    */
   unbanned_by_id?: string;
 
@@ -26228,6 +26291,8 @@ export interface UpdateAppRequest {
   image_moderation_enabled?: boolean;
 
   max_aggregated_activities_length?: number;
+
+  member_custom_on_mentioned_users_enabled?: boolean;
 
   member_custom_on_messages_enabled?: boolean;
 
@@ -27087,6 +27152,8 @@ export interface UpdateExternalStorageResponse {
 }
 
 export interface UpdateFeedGroupRequest {
+  default_follower_role?: string;
+
   default_visibility?:
     'public' | 'visible' | 'followers' | 'members' | 'private';
 
@@ -27268,6 +27335,9 @@ export interface UpdateFollowRequest {
    */
   enrich_own_fields?: boolean;
 
+  /**
+   * Optional role for the follower in the follow relationship. Server-side only, and one of 'feed_follower' (the default) or 'feed_member_viewer'.
+   */
   follower_role?: string;
 
   /**

--- a/src/gen/video/VideoApi.ts
+++ b/src/gen/video/VideoApi.ts
@@ -1955,11 +1955,11 @@ export class VideoApi {
 
   async getDailyDigest(request?: {
     date?: string;
-    app_id?: string;
+    target_app_id?: string;
   }): Promise<StreamResponse<GetDailyDigestResponse>> {
     const queryParams = {
       date: request?.date,
-      app_id: request?.app_id,
+      target_app_id: request?.target_app_id,
     };
 
     const response = await this.apiClient.sendRequest<


### PR DESCRIPTION
## Summary

Regenerated `src/gen` from the chat OpenAPI spec on the matching chat branch [`feature/feeds-1843-default-follower-role-per-group`](https://github.com/GetStream/chat/tree/feature/feeds-1843-default-follower-role-per-group) (FEEDS-1843), which adds a configurable **default follower role per feed group**.

`default_follower_role` seeds `follower_role` on new follows of feeds in a group, so an app can have e.g. a `premium` group whose followers default to `feed_member_viewer` (read, react, vote; no commenting) without a webhook round-trip and the permission window it leaves open.

Surface:

| model | shape |
|---|---|
| `CreateFeedGroupRequest` | `default_follower_role?: string` |
| `UpdateFeedGroupRequest` | `default_follower_role?: string` |
| `GetOrCreateFeedGroupRequest` | `default_follower_role?: string` |
| `FeedGroupResponse` | `default_follower_role?: string` |
| `FeedGroup` | `default_follower_role: string` (required, matching the adjacent `default_visibility`) |

## Why this branch exists now

`tests/qa/Makefile` in the chat repo probes this repo for a branch whose name matches the chat branch and swaps `@stream-io/node-sdk` to it, falling back to `main`. The chat PR's QA tests use the typed `default_follower_role` field, so they need this branch to resolve. Verified locally:

```
ℹ️  Swapped @stream-io/node-sdk: npm 0.8.3 → git branch 'feature/feeds-1843-default-follower-role-per-group' (0.8.3)
Test Files  3 passed (3)
     Tests  237 passed (237)
```

## Notes for review

**`src/gen` is regenerated wholesale**, so this diff is not limited to the field above. It also carries chat API surface merged since v0.8.3 that has not been released yet:

- `ReminderResponseData` → `CreateReminderResponse` (rename + new decoder)
- `member_custom_on_mentioned_users_enabled`
- `mentioned_channel_members`
- `create_users`
- `privacy_settings`, `teams_role`, `filter_conditions`, and related fields

That is inherent to regenerating the client and is what the post-release SDK regeneration would produce anyway — but it does mean approving this approves more than FEEDS-1843. Worth sequencing against the chat release if that matters.

No hand-edits: every file under `src/gen` is generator output (`./generate-openapi.sh`), followed by the repo's own `yarn lint:gen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)